### PR TITLE
Improve radar visuals and ITC spider charts

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     .wrap{ max-width: 1200px; margin: 28px auto 64px; padding: 0 20px; }
 
     /* Header */
-    header.hero{ display:flex; align-items:center; gap:16px; padding:16px 18px; border:1px solid var(--line); border-radius:var(--radius); background:linear-gradient(180deg, #f7fbff 0%, #fff 100%); box-shadow:var(--shadow); }
+    header.hero{ display:flex; align-items:center; gap:16px; padding:16px 18px; border:1px solid var(--line); border-radius:var(--radius); background:linear-gradient(180deg, #f7fbff 0%, #fff 100%); box-shadow:var(--shadow); flex-wrap:wrap; }
     .logo{ height:56px; width:auto; }
     .brand{ font-weight:800; font-size: clamp(18px,2.2vw,22px); letter-spacing:.2px; color:var(--blue-4); }
     .nav{ margin-left:auto; }
@@ -41,9 +41,11 @@
     /* Radar */
     .radar-wrap{ position:relative; border:1px solid var(--line); border-radius:var(--radius); padding:16px; background: #fff; box-shadow: var(--shadow); }
     .radar{ position:relative; width:100%; max-width:100%; height: 360px; margin:auto; background:
-      radial-gradient(circle at center, rgba(0,123,255,.06) 0 1px, transparent 1px) 0 0/24px 24px; border-radius:14px; overflow:hidden; }
+      radial-gradient(circle at center, rgba(0,123,255,.04) 0 1px, transparent 1px) 0 0/24px 24px; border-radius:14px; overflow:hidden; }
     .radar svg{ position:absolute; inset:0; width:100%; height:100%; }
-    .ring-label{ display:none; }
+    .ring-label{ display:block; font-size:12px; fill:var(--blue-4); font-weight:600; opacity:.85; }
+    .axis-line{ stroke:rgba(0,71,179,.25); stroke-width:1; stroke-dasharray:4 4; }
+    .ring-zone{ stroke:rgba(0,71,179,.35); stroke-width:1.2; }
 
     .radar-legend{ display:flex; gap:16px; flex-wrap:wrap; align-items:center; justify-content:flex-start; padding-top:10px; font-size:12px; color:#2b3b6a; }
     .radar-legend .lg{ display:inline-flex; align-items:center; gap:8px; }
@@ -53,6 +55,8 @@
     .dot{ cursor:pointer; transition: opacity .15s ease; }
     .dot circle{ filter: drop-shadow(0 2px 6px rgba(0,0,0,.15)); }
     .dot text{ font-size:12px; font-weight:700; fill:#0b0d12; paint-order: stroke; stroke: #fff; stroke-width: 3px; }
+    .dot text[data-align="left"]{ text-anchor:end; }
+    .dot text[data-align="center"]{ text-anchor:middle; }
 
     /* Board */
     h2{ margin: 26px 0 10px; font-size: clamp(20px,2.4vw,28px); color:var(--blue-4); }
@@ -60,7 +64,22 @@
 
     .board{ display:grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap:14px; }
     @media (max-width: 980px){ .board{ grid-template-columns: repeat(2, minmax(0,1fr)); } }
-    @media (max-width: 640px){ .board{ grid-template-columns: 1fr; } .radar{ height:320px; } }
+    @media (max-width: 760px){
+      header.hero{ flex-direction:column; align-items:flex-start; }
+      .nav{ width:100%; display:flex; justify-content:flex-start; }
+      .login-link{ width:100%; justify-content:center; }
+    }
+    @media (max-width: 640px){
+      .board{ grid-template-columns: 1fr; }
+      .radar{ height:320px; }
+      .radar-wrap{ padding:12px; }
+    }
+    @media (max-width: 480px){
+      header.hero{ padding:14px; }
+      .search{ flex-direction:column; }
+      .search input{ padding-left:38px; }
+      .radar{ height:280px; }
+    }
 
     .tile{ position:relative; background:var(--card); border:1px solid var(--line); border-radius:14px; padding:14px; box-shadow: var(--shadow); text-decoration:none; color:inherit; display:flex; flex-direction:column; gap:10px; }
     .tile:hover{ border-color: var(--blue-2); box-shadow: 0 8px 30px rgba(0,123,255,.12); }
@@ -151,6 +170,7 @@ const rings = [
   {id:'production',label:'Продукция',  r:180, color:'#1c8fff'},
   {id:'scale',     label:'Масштаб',    r:230, color:'#0b5fd1'}
 ];
+let lastRadarData = technologies;
 
 function polarToXY(cx, cy, r, angleDeg){
   const a = (angleDeg - 90) * Math.PI/180; // 0° вверх
@@ -158,6 +178,7 @@ function polarToXY(cx, cy, r, angleDeg){
 }
 
 function renderRadar(data){
+  lastRadarData = data;
   const w = radarEl.clientWidth || radarEl.offsetWidth || 800;
   const h = radarEl.clientHeight || 360;
   const cx = w/2, cy = h/2;
@@ -167,17 +188,44 @@ function renderRadar(data){
   const svg = document.createElementNS('http://www.w3.org/2000/svg','svg');
   svg.setAttribute('viewBox', `0 0 ${w} ${h}`);
 
-  // Кольца зрелости
-  rings.forEach(r=>{
+  const defs = document.createElementNS(svg.namespaceURI,'defs');
+  const lg = document.createElementNS(svg.namespaceURI,'linearGradient');
+  lg.setAttribute('id','grad'); lg.setAttribute('x1','0'); lg.setAttribute('x2','1');
+  const s1 = document.createElementNS(svg.namespaceURI,'stop'); s1.setAttribute('offset','0%'); s1.setAttribute('stop-color','var(--blue-1)');
+  const s2 = document.createElementNS(svg.namespaceURI,'stop'); s2.setAttribute('offset','100%'); s2.setAttribute('stop-color','var(--blue-2)');
+  lg.appendChild(s1); lg.appendChild(s2); defs.appendChild(lg); svg.appendChild(defs);
+
+  const ringGroup = document.createElementNS(svg.namespaceURI,'g');
+  rings.forEach((r, idx)=>{
     const R = r.r * scale;
     const c = document.createElementNS(svg.namespaceURI,'circle');
     c.setAttribute('cx', cx); c.setAttribute('cy', cy); c.setAttribute('r', R);
-    c.setAttribute('fill','none'); c.setAttribute('stroke','var(--line)'); c.setAttribute('stroke-width','1.4');
-    svg.appendChild(c);
+    c.setAttribute('class','ring-zone');
+    c.setAttribute('fill', idx % 2 === 0 ? 'rgba(0,123,255,.09)' : 'rgba(0,123,255,.05)');
+    ringGroup.appendChild(c);
+
     const t = document.createElementNS(svg.namespaceURI,'text');
-    t.setAttribute('x', cx + R + 8); t.setAttribute('y', cy - 6);
-    t.setAttribute('class','ring-label'); t.textContent = r.label; svg.appendChild(t);
+    t.setAttribute('x', cx);
+    t.setAttribute('y', Math.max(18, cy - R + 14));
+    t.setAttribute('class','ring-label');
+    t.setAttribute('text-anchor','middle');
+    t.textContent = r.label;
+    ringGroup.appendChild(t);
   });
+  svg.appendChild(ringGroup);
+
+  const axes = document.createElementNS(svg.namespaceURI,'g');
+  const axisCount = 8;
+  for(let i=0;i<axisCount;i++){
+    const angle = (360/axisCount)*i;
+    const end = polarToXY(cx, cy, rings[rings.length-1].r * scale, angle);
+    const line = document.createElementNS(svg.namespaceURI,'line');
+    line.setAttribute('x1', cx); line.setAttribute('y1', cy);
+    line.setAttribute('x2', end.x); line.setAttribute('y2', end.y);
+    line.setAttribute('class','axis-line');
+    axes.appendChild(line);
+  }
+  svg.appendChild(axes);
 
   if(!data.length){
     radarEl.innerHTML = '';
@@ -185,12 +233,7 @@ function renderRadar(data){
     return;
   }
 
-  const defs = document.createElementNS(svg.namespaceURI,'defs');
-  const lg = document.createElementNS(svg.namespaceURI,'linearGradient');
-  lg.setAttribute('id','grad'); lg.setAttribute('x1','0'); lg.setAttribute('x2','1');
-  const s1 = document.createElementNS(svg.namespaceURI,'stop'); s1.setAttribute('offset','0%'); s1.setAttribute('stop-color','var(--blue-1)');
-  const s2 = document.createElementNS(svg.namespaceURI,'stop'); s2.setAttribute('offset','100%'); s2.setAttribute('stop-color','var(--blue-2)');
-  lg.appendChild(s1); lg.appendChild(s2); defs.appendChild(lg); svg.appendChild(defs);
+  const labelBoxes = [];
 
   data.forEach((item, idx)=>{
     const R = (rings.find(r=>r.id===item.ring)?.r || rings[0].r) * scale;
@@ -202,8 +245,49 @@ function renderRadar(data){
     circle.setAttribute('fill','url(#grad)'); circle.setAttribute('stroke','var(--blue-3)'); circle.setAttribute('stroke-width','1');
 
     const label = document.createElementNS(svg.namespaceURI,'text');
-    label.setAttribute('x', pos.x + 14); label.setAttribute('y', pos.y - 12);
     label.textContent = item.name;
+
+    const align = pos.x < cx - 40 ? 'left' : (pos.x > cx + 40 ? 'right' : 'center');
+    let labelX = align === 'left' ? pos.x - 16 : align === 'right' ? pos.x + 16 : pos.x;
+    let labelY = pos.y - 12;
+    const approxWidth = Math.min(220, item.name.length * 6.8);
+    const labelHeight = 18;
+    const box = {
+      x: align === 'left' ? labelX - approxWidth : labelX,
+      y: labelY - labelHeight + 6,
+      width: approxWidth,
+      height: labelHeight
+    };
+
+    if(box.y < 12){
+      const diff = 12 - box.y;
+      box.y += diff; labelY += diff;
+    }
+
+    const collide = (a,b)=> !(a.x + a.width < b.x || b.x + b.width < a.x || a.y + a.height < b.y || b.y + b.height < a.y);
+    let guard = 0;
+    while(labelBoxes.some(b=>collide(b, box)) && guard < 12){
+      box.y += labelHeight;
+      labelY += labelHeight;
+      guard++;
+    }
+
+    if(align === 'right' && box.x + box.width > w - 8){
+      const shift = box.x + box.width - (w - 8);
+      labelX -= shift;
+      box.x -= shift;
+    }
+    if(align === 'left' && box.x < 8){
+      const shift = 8 - box.x;
+      labelX += shift;
+      box.x += shift;
+    }
+
+    label.setAttribute('x', labelX);
+    label.setAttribute('y', labelY);
+    if(align === 'left'){ label.setAttribute('text-anchor','end'); label.dataset.align='left'; }
+    else if(align === 'right'){ label.setAttribute('text-anchor','start'); label.dataset.align='right'; }
+    else { label.setAttribute('text-anchor','middle'); label.dataset.align='center'; }
 
     g.appendChild(circle);
     g.appendChild(label);
@@ -214,6 +298,7 @@ function renderRadar(data){
     g.addEventListener('keydown', (e)=>{ if(e.key==='Enter') go(); });
 
     svg.appendChild(g);
+    labelBoxes.push(box);
   });
 
   radarEl.innerHTML = '';
@@ -261,10 +346,14 @@ function setupSearch(){
 }
 
 // init
-renderRadar(technologies);
-renderBoard(technologies);
-setupSearch();
-window.addEventListener('resize', ()=> renderRadar(technologies));
+  renderRadar(technologies);
+  renderBoard(technologies);
+  setupSearch();
+  let radarResizeTimer;
+  window.addEventListener('resize', ()=>{
+    clearTimeout(radarResizeTimer);
+    radarResizeTimer = setTimeout(()=> renderRadar(lastRadarData), 160);
+  });
 
 const loginLink = document.querySelector('.login-link');
 function configureLoginLink(){

--- a/streaming-rt/index.html
+++ b/streaming-rt/index.html
@@ -46,6 +46,17 @@
     .card{ padding:14px; border-radius:14px; background:#fff; border:1px solid var(--line); box-shadow: var(--shadow); }
     .card h4{ margin:0 0 6px; font-size:16px; color:var(--blue-3); }
 
+    .itc-layout{ display:grid; grid-template-columns:minmax(0,320px) minmax(0,1fr); gap:18px; align-items:center; }
+    .itc-spider{ margin:0; padding:16px; border-radius:14px; border:1px solid var(--line); background:#fff; box-shadow:var(--shadow); display:flex; flex-direction:column; align-items:center; gap:12px; }
+    .itc-spider svg{ width:100%; height:auto; max-width:320px; }
+    .itc-spider figcaption{ margin:0; font-size:12px; color:var(--muted); text-align:center; }
+    .itc-cards{ display:grid; grid-template-columns:repeat(2, minmax(0,1fr)); gap:12px; }
+    .itc-spider .grid-ring{ stroke:rgba(0,71,179,.25); stroke-width:1; }
+    .itc-spider .axis{ stroke:rgba(0,71,179,.3); stroke-width:1; stroke-dasharray:4 4; }
+    .itc-spider .area{ fill:rgba(0,123,255,.22); stroke:var(--blue-2); stroke-width:2; }
+    .itc-spider .dot{ fill:#fff; stroke:var(--blue-3); stroke-width:1.4; }
+    .itc-spider .axis-label{ font-size:12px; fill:var(--blue-3); font-weight:600; }
+
     .roadmap{ position:relative; padding:16px; background:#fff; border:1px solid var(--line); border-radius:var(--radius); }
     .roadmap-grid{ display:grid; grid-template-columns: repeat(3, 1fr); gap:16px; }
     .phase{ position:relative; background:#fff; border:1px solid var(--line); border-radius:14px; padding:14px; box-shadow: var(--shadow); }
@@ -69,6 +80,7 @@
     summary{ cursor:pointer; font-weight:700; color:var(--blue-3); }
 
     .source-list{ columns: 2; gap: 18px; }
+    .source-list p{ margin:0 0 10px; }
     .source-list a{ color: var(--blue-2); text-decoration: none; }
     .source-list a:hover{ text-decoration: underline; }
 
@@ -79,6 +91,10 @@
 
     footer{ color:var(--muted); font-size:12px; margin-top: 22px; text-align:center; }
 
+    @media (max-width: 960px){
+      .itc-layout{ grid-template-columns:1fr; }
+      .itc-spider{ max-width:420px; margin:0 auto; }
+    }
     @media (max-width: 880px){
       .stats{ grid-template-columns: repeat(2, minmax(0,1fr)); }
       .grid-2{ grid-template-columns:1fr; }
@@ -86,6 +102,16 @@
       .cards{ grid-template-columns:1fr; }
       .source-list{ columns: 1; }
       .roadmap-grid{ grid-template-columns:1fr; }
+      .itc-cards{ grid-template-columns:1fr; }
+    }
+    @media (max-width: 640px){
+      .stats{ grid-template-columns:1fr; }
+      header.hero{ padding:20px 18px; }
+      section{ padding:16px; }
+    }
+    @media (max-width: 520px){
+      .tag{ font-size:12px; }
+      .tagrow{ gap:6px; }
     }
     h2::after{ content:""; display:block; width:56px; height:4px; background: linear-gradient(90deg, var(--blue-2), var(--blue-1)); border-radius:2px; margin-top:8px; }
   </style>
@@ -144,11 +170,16 @@
 
     <h2>Индекс технологичности (ITC)</h2>
     <section>
-      <div class="cards">
-        <div class="card"><h4>SM — 42</h4><p>Научный моментум замедляется: рост публикаций стабилизировался, фокус смещается в инженерную оптимизацию.</p></div>
-        <div class="card"><h4>NV — 20</h4><p>Высокая зрелость и оптимизация стоимости: внедрение управляемых сервисов, BYOC и serverless‑форматов.</p></div>
-        <div class="card"><h4>IP — 2</h4><p>Импакт пока нишевый: требуется накопление референсов и отраслевых ссылок для масштабных решений.</p></div>
-        <div class="card"><h4>HR — 8</h4><p>Высокие барьеры входа и лабораторная стадия: компетенции по stateful streams и exactly-once дефицитны.</p></div>
+      <div class="itc-layout">
+        <figure class="itc-spider" data-labels="SM,NV,IP,HR" data-values="42,20,2,8" data-max="100" aria-label="Спайдер-диаграмма индекса технологичности">
+          <figcaption>SM — научный моментум, NV — новизна, IP — импакт, HR — готовность команд.</figcaption>
+        </figure>
+        <div class="itc-cards">
+          <div class="card"><h4>SM — 42</h4><p>Научный моментум замедляется: рост публикаций стабилизировался, фокус смещается в инженерную оптимизацию.</p></div>
+          <div class="card"><h4>NV — 20</h4><p>Высокая зрелость и оптимизация стоимости: внедрение управляемых сервисов, BYOC и serverless‑форматов.</p></div>
+          <div class="card"><h4>IP — 2</h4><p>Импакт пока нишевый: требуется накопление референсов и отраслевых ссылок для масштабных решений.</p></div>
+          <div class="card"><h4>HR — 8</h4><p>Высокие барьеры входа и лабораторная стадия: компетенции по stateful streams и exactly-once дефицитны.</p></div>
+        </div>
       </div>
     </section>
 
@@ -392,21 +423,116 @@
     <h2>Источники</h2>
     <section>
       <div class="source-list">
-        <a href="https://www.forrester.com/report/the-forrester-wave-tm-streaming-data-platforms-q4-2023/RES178464" target="_blank" rel="noopener">Forrester (2023) — Streaming Data Platforms Wave</a>
-        <a href="https://www.forrester.com/report/the-streaming-data-platforms-landscape-q3-2025/RES184143" target="_blank" rel="noopener">Forrester (2025) — Landscape</a>
-        <a href="https://www.gartner.com/en/documents/4347499" target="_blank" rel="noopener">Gartner Document 4347499</a>
-        <a href="https://www.confluent.io/press-release/confluent-plans-immerok-acquisition-to-accelerate-cloud-native-apache-flink/" target="_blank" rel="noopener">Confluent plans Immerok acquisition (2023)</a>
-        <a href="https://investors.confluent.io/news-releases/news-release-details/confluent-announces-general-availability-confluent-cloud-apache" target="_blank" rel="noopener">Confluent Cloud for Apache Flink GA (2024)</a>
-        <a href="https://investors.confluent.io/news-releases/news-release-details/confluent-acquires-warpstream-advance-next-gen-byoc-data" target="_blank" rel="noopener">Confluent acquires WarpStream (2024)</a>
-        <a href="https://www.redpanda.com/press/redpanda-raises-100m-in-series-c-funding" target="_blank" rel="noopener">Redpanda raises $100M Series C (2023)</a>
-        <a href="https://www.redpanda.com/press/redpanda-acquires-benthos" target="_blank" rel="noopener">Redpanda acquires Benthos (2024)</a>
-        <a href="https://www.redpanda.com/press/redpanda-raises-100m-launches-enterprise-agentic-ai-platform" target="_blank" rel="noopener">Redpanda raises $100M Series D (2025)</a>
-        <a href="https://www.businesswire.com/news/home/20240313224497/en/WarpStream-Labs-Raises-20M-to-Modernize-Data-Streaming-with-a-Cloud-Native-Replacement-for-Apache-Kafka" target="_blank" rel="noopener">WarpStream Labs raises $20M (2024)</a>
-        <a href="https://www.cncf.io/announcements/2024/01/25/cloud-native-computing-foundation-announces-the-graduation-of-cloudevents/" target="_blank" rel="noopener">CNCF CloudEvents Graduation (2024)</a>
+        <p><a href="https://www.forrester.com/report/the-forrester-wave-tm-streaming-data-platforms-q4-2023/RES178464" target="_blank" rel="noopener">Forrester (2023) — Streaming Data Platforms Wave</a></p>
+        <p><a href="https://www.forrester.com/report/the-streaming-data-platforms-landscape-q3-2025/RES184143" target="_blank" rel="noopener">Forrester (2025) — Landscape</a></p>
+        <p><a href="https://www.gartner.com/en/documents/4347499" target="_blank" rel="noopener">Gartner Document 4347499</a></p>
+        <p><a href="https://www.confluent.io/press-release/confluent-plans-immerok-acquisition-to-accelerate-cloud-native-apache-flink/" target="_blank" rel="noopener">Confluent plans Immerok acquisition (2023)</a></p>
+        <p><a href="https://investors.confluent.io/news-releases/news-release-details/confluent-announces-general-availability-confluent-cloud-apache" target="_blank" rel="noopener">Confluent Cloud for Apache Flink GA (2024)</a></p>
+        <p><a href="https://investors.confluent.io/news-releases/news-release-details/confluent-acquires-warpstream-advance-next-gen-byoc-data" target="_blank" rel="noopener">Confluent acquires WarpStream (2024)</a></p>
+        <p><a href="https://www.redpanda.com/press/redpanda-raises-100m-in-series-c-funding" target="_blank" rel="noopener">Redpanda raises $100M Series C (2023)</a></p>
+        <p><a href="https://www.redpanda.com/press/redpanda-acquires-benthos" target="_blank" rel="noopener">Redpanda acquires Benthos (2024)</a></p>
+        <p><a href="https://www.redpanda.com/press/redpanda-raises-100m-launches-enterprise-agentic-ai-platform" target="_blank" rel="noopener">Redpanda raises $100M Series D (2025)</a></p>
+        <p><a href="https://www.businesswire.com/news/home/20240313224497/en/WarpStream-Labs-Raises-20M-to-Modernize-Data-Streaming-with-a-Cloud-Native-Replacement-for-Apache-Kafka" target="_blank" rel="noopener">WarpStream Labs raises $20M (2024)</a></p>
+        <p><a href="https://www.cncf.io/announcements/2024/01/25/cloud-native-computing-foundation-announces-the-graduation-of-cloudevents/" target="_blank" rel="noopener">CNCF CloudEvents Graduation (2024)</a></p>
       </div>
     </section>
 
     <footer>© 2025 • SCI • Главная по технологиям KG</footer>
   </div>
+<script>
+  (function(){
+    const SVG_NS = 'http://www.w3.org/2000/svg';
+    function renderSpiders(){
+      document.querySelectorAll('.itc-spider').forEach(container=>{
+        const labels = (container.dataset.labels || '').split(',').map(s=>s.trim()).filter(Boolean);
+        const raw = (container.dataset.values || '').split(',').map(s=> Number(s.trim()));
+        if(!labels.length) return;
+        const max = Number(container.dataset.max || 100) || 100;
+        const levels = Number(container.dataset.levels || 5) || 5;
+        const existing = container.querySelector('svg');
+        if(existing){ existing.remove(); }
+
+        const svg = document.createElementNS(SVG_NS, 'svg');
+        svg.setAttribute('viewBox','0 0 320 320');
+        svg.setAttribute('width','100%');
+        svg.setAttribute('height','100%');
+        svg.setAttribute('focusable','false');
+
+        const center = 160;
+        const radius = 120;
+
+        const toPoint = (ratio, idx)=>{
+          const angle = -Math.PI/2 + idx * (Math.PI*2/labels.length);
+          const r = radius * ratio;
+          return {
+            x: center + Math.cos(angle) * r,
+            y: center + Math.sin(angle) * r
+          };
+        };
+
+        const gridGroup = document.createElementNS(SVG_NS,'g');
+        for(let level=1; level<=levels; level++){
+          const pts = labels.map((_, idx)=> toPoint(level/levels, idx));
+          const polygon = document.createElementNS(SVG_NS,'polygon');
+          polygon.setAttribute('points', pts.map(p=> `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' '));
+          polygon.setAttribute('class','grid-ring');
+          polygon.setAttribute('fill', level % 2 === 0 ? 'rgba(0,123,255,.05)' : 'rgba(0,123,255,.1)');
+          gridGroup.appendChild(polygon);
+        }
+        svg.appendChild(gridGroup);
+
+        const axisGroup = document.createElementNS(SVG_NS,'g');
+        labels.forEach((label, idx)=>{
+          const end = toPoint(1, idx);
+          const axis = document.createElementNS(SVG_NS,'line');
+          axis.setAttribute('x1', center); axis.setAttribute('y1', center);
+          axis.setAttribute('x2', end.x); axis.setAttribute('y2', end.y);
+          axis.setAttribute('class','axis');
+          axisGroup.appendChild(axis);
+
+          const labelPoint = toPoint(1.12, idx);
+          const text = document.createElementNS(SVG_NS,'text');
+          text.textContent = label;
+          text.setAttribute('x', labelPoint.x);
+          text.setAttribute('y', labelPoint.y);
+          text.setAttribute('class','axis-label');
+          const anchor = labelPoint.x < center - 5 ? 'end' : (labelPoint.x > center + 5 ? 'start' : 'middle');
+          text.setAttribute('text-anchor', anchor);
+          axisGroup.appendChild(text);
+        });
+        svg.appendChild(axisGroup);
+
+        const valuePoints = labels.map((_, idx)=>{
+          const value = Math.max(0, Math.min(raw[idx] ?? 0, max));
+          return toPoint(value / max, idx);
+        });
+
+        const areaGroup = document.createElementNS(SVG_NS,'g');
+        const area = document.createElementNS(SVG_NS,'polygon');
+        area.setAttribute('points', valuePoints.map(p=> `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' '));
+        area.setAttribute('class','area');
+        area.setAttribute('fill', 'rgba(0,123,255,.28)');
+        areaGroup.appendChild(area);
+
+        valuePoints.forEach(pt=>{
+          const dot = document.createElementNS(SVG_NS,'circle');
+          dot.setAttribute('cx', pt.x); dot.setAttribute('cy', pt.y); dot.setAttribute('r', 4);
+          dot.setAttribute('class','dot');
+          areaGroup.appendChild(dot);
+        });
+
+        svg.appendChild(areaGroup);
+        container.insertBefore(svg, container.firstChild);
+      });
+    }
+
+    renderSpiders();
+    let resizeTimer;
+    window.addEventListener('resize', ()=>{
+      clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(renderSpiders, 160);
+    });
+  })();
+</script>
 </body>
 </html>

--- a/streaming/index.html
+++ b/streaming/index.html
@@ -44,6 +44,17 @@
     .card{ padding:14px; border-radius:14px; background:#fff; border:1px solid var(--line); box-shadow: var(--shadow); }
     .card h4{ margin:0 0 6px; font-size:16px; color:var(--blue-3); }
 
+    .itc-layout{ display:grid; grid-template-columns:minmax(0,320px) minmax(0,1fr); gap:18px; align-items:center; }
+    .itc-spider{ margin:0; padding:16px; border-radius:14px; border:1px solid var(--line); background:#fff; box-shadow:var(--shadow); display:flex; flex-direction:column; align-items:center; gap:12px; }
+    .itc-spider svg{ width:100%; height:auto; max-width:320px; }
+    .itc-spider figcaption{ margin:0; font-size:12px; color:var(--muted); text-align:center; }
+    .itc-cards{ display:grid; grid-template-columns:repeat(2, minmax(0,1fr)); gap:12px; }
+    .itc-spider .grid-ring{ stroke:rgba(0,71,179,.25); stroke-width:1; }
+    .itc-spider .axis{ stroke:rgba(0,71,179,.3); stroke-width:1; stroke-dasharray:4 4; }
+    .itc-spider .area{ fill:rgba(0,123,255,.22); stroke:var(--blue-2); stroke-width:2; }
+    .itc-spider .dot{ fill:#fff; stroke:var(--blue-3); stroke-width:1.4; }
+    .itc-spider .axis-label{ font-size:12px; fill:var(--blue-3); font-weight:600; }
+
     .roadmap{ position:relative; padding:16px; background:#fff; border:1px solid var(--line); border-radius:var(--radius); }
     .roadmap-grid{ display:grid; grid-template-columns: repeat(3, 1fr); gap:16px; }
     .phase{ position:relative; background:#fff; border:1px solid var(--line); border-radius:14px; padding:14px; box-shadow: var(--shadow); }
@@ -67,6 +78,7 @@
     summary{ cursor:pointer; font-weight:700; color:var(--blue-3); }
 
     .source-list{ columns: 2; gap: 18px; }
+    .source-list p{ margin:0 0 10px; }
     .source-list a{ color: var(--blue-2); text-decoration: none; }
     .source-list a:hover{ text-decoration: underline; }
 
@@ -77,6 +89,10 @@
 
     footer{ color:var(--muted); font-size:12px; margin-top: 22px; text-align:center; }
 
+    @media (max-width: 960px){
+      .itc-layout{ grid-template-columns:1fr; }
+      .itc-spider{ max-width:420px; margin:0 auto; }
+    }
     @media (max-width: 880px){
       .stats{ grid-template-columns: repeat(2, minmax(0,1fr)); }
       .grid-2{ grid-template-columns:1fr; }
@@ -84,6 +100,16 @@
       .cards{ grid-template-columns:1fr; }
       .source-list{ columns: 1; }
       .roadmap-grid{ grid-template-columns:1fr; }
+      .itc-cards{ grid-template-columns:1fr; }
+    }
+    @media (max-width: 640px){
+      .stats{ grid-template-columns:1fr; }
+      header.hero{ padding:20px 18px; }
+      section{ padding:16px; }
+    }
+    @media (max-width: 520px){
+      .tag{ font-size:12px; }
+      .tagrow{ gap:6px; }
     }
     h2::after{ content:""; display:block; width:56px; height:4px; background: linear-gradient(90deg, var(--blue-2), var(--blue-1)); border-radius:2px; margin-top:8px; }
   </style>
@@ -141,11 +167,16 @@
 
     <h2>Индекс технологичности (ITC)</h2>
     <section>
-      <div class="cards">
-        <div class="card"><h4>SM — 42</h4><p>Научный моментум замедляется: рост публикаций стабилизировался, фокус смещается в инженерную оптимизацию.</p></div>
-        <div class="card"><h4>NV — 20</h4><p>Высокая зрелость и оптимизация стоимости: внедрение управляемых сервисов, BYOC и serverless‑форматов.</p></div>
-        <div class="card"><h4>IP — 2</h4><p>Импакт пока нишевый: требуется накопление референсов и отраслевых ссылок для масштабных решений.</p></div>
-        <div class="card"><h4>HR — 8</h4><p>Высокие барьеры входа и лабораторная стадия: компетенции по stateful streams и exactly-once дефицитны.</p></div>
+      <div class="itc-layout">
+        <figure class="itc-spider" data-labels="SM,NV,IP,HR" data-values="42,20,2,8" data-max="100" aria-label="Спайдер-диаграмма индекса технологичности">
+          <figcaption>SM — научный моментум, NV — новизна, IP — импакт, HR — готовность команд.</figcaption>
+        </figure>
+        <div class="itc-cards">
+          <div class="card"><h4>SM — 42</h4><p>Научный моментум замедляется: рост публикаций стабилизировался, фокус смещается в инженерную оптимизацию.</p></div>
+          <div class="card"><h4>NV — 20</h4><p>Высокая зрелость и оптимизация стоимости: внедрение управляемых сервисов, BYOC и serverless‑форматов.</p></div>
+          <div class="card"><h4>IP — 2</h4><p>Импакт пока нишевый: требуется накопление референсов и отраслевых ссылок для масштабных решений.</p></div>
+          <div class="card"><h4>HR — 8</h4><p>Высокие барьеры входа и лабораторная стадия: компетенции по stateful streams и exactly-once дефицитны.</p></div>
+        </div>
       </div>
     </section>
 
@@ -381,21 +412,116 @@
     <h2>Источники</h2>
     <section>
       <div class="source-list">
-        <a href="https://www.forrester.com/report/the-forrester-wave-tm-streaming-data-platforms-q4-2023/RES178464" target="_blank" rel="noopener">Forrester (2023) — Streaming Data Platforms Wave</a>
-        <a href="https://www.forrester.com/report/the-streaming-data-platforms-landscape-q3-2025/RES184143" target="_blank" rel="noopener">Forrester (2025) — Landscape</a>
-        <a href="https://www.gartner.com/en/documents/4347499" target="_blank" rel="noopener">Gartner Document 4347499</a>
-        <a href="https://www.confluent.io/press-release/confluent-plans-immerok-acquisition-to-accelerate-cloud-native-apache-flink/" target="_blank" rel="noopener">Confluent plans Immerok acquisition (2023)</a>
-        <a href="https://investors.confluent.io/news-releases/news-release-details/confluent-announces-general-availability-confluent-cloud-apache" target="_blank" rel="noopener">Confluent Cloud for Apache Flink GA (2024)</a>
-        <a href="https://investors.confluent.io/news-releases/news-release-details/confluent-acquires-warpstream-advance-next-gen-byoc-data" target="_blank" rel="noopener">Confluent acquires WarpStream (2024)</a>
-        <a href="https://www.redpanda.com/press/redpanda-raises-100m-in-series-c-funding" target="_blank" rel="noopener">Redpanda raises $100M Series C (2023)</a>
-        <a href="https://www.redpanda.com/press/redpanda-acquires-benthos" target="_blank" rel="noopener">Redpanda acquires Benthos (2024)</a>
-        <a href="https://www.redpanda.com/press/redpanda-raises-100m-launches-enterprise-agentic-ai-platform" target="_blank" rel="noopener">Redpanda raises $100M Series D (2025)</a>
-        <a href="https://www.businesswire.com/news/home/20240313224497/en/WarpStream-Labs-Raises-20M-to-Modernize-Data-Streaming-with-a-Cloud-Native-Replacement-for-Apache-Kafka" target="_blank" rel="noopener">WarpStream Labs raises $20M (2024)</a>
-        <a href="https://www.cncf.io/announcements/2024/01/25/cloud-native-computing-foundation-announces-the-graduation-of-cloudevents/" target="_blank" rel="noopener">CNCF CloudEvents Graduation (2024)</a>
+        <p><a href="https://www.forrester.com/report/the-forrester-wave-tm-streaming-data-platforms-q4-2023/RES178464" target="_blank" rel="noopener">Forrester (2023) — Streaming Data Platforms Wave</a></p>
+        <p><a href="https://www.forrester.com/report/the-streaming-data-platforms-landscape-q3-2025/RES184143" target="_blank" rel="noopener">Forrester (2025) — Landscape</a></p>
+        <p><a href="https://www.gartner.com/en/documents/4347499" target="_blank" rel="noopener">Gartner Document 4347499</a></p>
+        <p><a href="https://www.confluent.io/press-release/confluent-plans-immerok-acquisition-to-accelerate-cloud-native-apache-flink/" target="_blank" rel="noopener">Confluent plans Immerok acquisition (2023)</a></p>
+        <p><a href="https://investors.confluent.io/news-releases/news-release-details/confluent-announces-general-availability-confluent-cloud-apache" target="_blank" rel="noopener">Confluent Cloud for Apache Flink GA (2024)</a></p>
+        <p><a href="https://investors.confluent.io/news-releases/news-release-details/confluent-acquires-warpstream-advance-next-gen-byoc-data" target="_blank" rel="noopener">Confluent acquires WarpStream (2024)</a></p>
+        <p><a href="https://www.redpanda.com/press/redpanda-raises-100m-in-series-c-funding" target="_blank" rel="noopener">Redpanda raises $100M Series C (2023)</a></p>
+        <p><a href="https://www.redpanda.com/press/redpanda-acquires-benthos" target="_blank" rel="noopener">Redpanda acquires Benthos (2024)</a></p>
+        <p><a href="https://www.redpanda.com/press/redpanda-raises-100m-launches-enterprise-agentic-ai-platform" target="_blank" rel="noopener">Redpanda raises $100M Series D (2025)</a></p>
+        <p><a href="https://www.businesswire.com/news/home/20240313224497/en/WarpStream-Labs-Raises-20M-to-Modernize-Data-Streaming-with-a-Cloud-Native-Replacement-for-Apache-Kafka" target="_blank" rel="noopener">WarpStream Labs raises $20M (2024)</a></p>
+        <p><a href="https://www.cncf.io/announcements/2024/01/25/cloud-native-computing-foundation-announces-the-graduation-of-cloudevents/" target="_blank" rel="noopener">CNCF CloudEvents Graduation (2024)</a></p>
       </div>
     </section>
 
     <footer>© 2025 • SCI • Главная по технологиям KG</footer>
   </div>
+<script>
+  (function(){
+    const SVG_NS = 'http://www.w3.org/2000/svg';
+    function renderSpiders(){
+      document.querySelectorAll('.itc-spider').forEach(container=>{
+        const labels = (container.dataset.labels || '').split(',').map(s=>s.trim()).filter(Boolean);
+        const raw = (container.dataset.values || '').split(',').map(s=> Number(s.trim()));
+        if(!labels.length) return;
+        const max = Number(container.dataset.max || 100) || 100;
+        const levels = Number(container.dataset.levels || 5) || 5;
+        const existing = container.querySelector('svg');
+        if(existing){ existing.remove(); }
+
+        const svg = document.createElementNS(SVG_NS, 'svg');
+        svg.setAttribute('viewBox','0 0 320 320');
+        svg.setAttribute('width','100%');
+        svg.setAttribute('height','100%');
+        svg.setAttribute('focusable','false');
+
+        const center = 160;
+        const radius = 120;
+
+        const toPoint = (ratio, idx)=>{
+          const angle = -Math.PI/2 + idx * (Math.PI*2/labels.length);
+          const r = radius * ratio;
+          return {
+            x: center + Math.cos(angle) * r,
+            y: center + Math.sin(angle) * r
+          };
+        };
+
+        const gridGroup = document.createElementNS(SVG_NS,'g');
+        for(let level=1; level<=levels; level++){
+          const pts = labels.map((_, idx)=> toPoint(level/levels, idx));
+          const polygon = document.createElementNS(SVG_NS,'polygon');
+          polygon.setAttribute('points', pts.map(p=> `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' '));
+          polygon.setAttribute('class','grid-ring');
+          polygon.setAttribute('fill', level % 2 === 0 ? 'rgba(0,123,255,.05)' : 'rgba(0,123,255,.1)');
+          gridGroup.appendChild(polygon);
+        }
+        svg.appendChild(gridGroup);
+
+        const axisGroup = document.createElementNS(SVG_NS,'g');
+        labels.forEach((label, idx)=>{
+          const end = toPoint(1, idx);
+          const axis = document.createElementNS(SVG_NS,'line');
+          axis.setAttribute('x1', center); axis.setAttribute('y1', center);
+          axis.setAttribute('x2', end.x); axis.setAttribute('y2', end.y);
+          axis.setAttribute('class','axis');
+          axisGroup.appendChild(axis);
+
+          const labelPoint = toPoint(1.12, idx);
+          const text = document.createElementNS(SVG_NS,'text');
+          text.textContent = label;
+          text.setAttribute('x', labelPoint.x);
+          text.setAttribute('y', labelPoint.y);
+          text.setAttribute('class','axis-label');
+          const anchor = labelPoint.x < center - 5 ? 'end' : (labelPoint.x > center + 5 ? 'start' : 'middle');
+          text.setAttribute('text-anchor', anchor);
+          axisGroup.appendChild(text);
+        });
+        svg.appendChild(axisGroup);
+
+        const valuePoints = labels.map((_, idx)=>{
+          const value = Math.max(0, Math.min(raw[idx] ?? 0, max));
+          return toPoint(value / max, idx);
+        });
+
+        const areaGroup = document.createElementNS(SVG_NS,'g');
+        const area = document.createElementNS(SVG_NS,'polygon');
+        area.setAttribute('points', valuePoints.map(p=> `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' '));
+        area.setAttribute('class','area');
+        area.setAttribute('fill', 'rgba(0,123,255,.28)');
+        areaGroup.appendChild(area);
+
+        valuePoints.forEach(pt=>{
+          const dot = document.createElementNS(SVG_NS,'circle');
+          dot.setAttribute('cx', pt.x); dot.setAttribute('cy', pt.y); dot.setAttribute('r', 4);
+          dot.setAttribute('class','dot');
+          areaGroup.appendChild(dot);
+        });
+
+        svg.appendChild(areaGroup);
+        container.insertBefore(svg, container.firstChild);
+      });
+    }
+
+    renderSpiders();
+    let resizeTimer;
+    window.addEventListener('resize', ()=>{
+      clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(renderSpiders, 160);
+    });
+  })();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enhance the landing radar with visible axes, labeled rings, better label placement, and mobile tweaks
- add responsive spider charts to the ITC sections of the streaming technology pages and adjust layouts for small screens
- format source lists as paragraph blocks for consistent spacing

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68fb88495678833383cbd01b052046fa