### PR TITLE
Add semantic data pipelines trend

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,6 +176,15 @@ const technologies = [
     link: makeLink('streaming-rt'),
     ring:'pilot',
     angle: 220
+  },
+  {
+    id:'semantic-pipelines',
+    slug:'semantic-pipelines',
+    name:'Семантические конвейеры интеграции и обработки данных',
+    keys:['Hybrid Vector-SQL','ANN/HNSW','Lineage','RAG','ISO GQL','SPARQL 1.2'],
+    link: makeLink('semantic-pipelines'),
+    ring:'production',
+    angle: 300
   }
 ];
 

--- a/semantic-pipelines/index.html
+++ b/semantic-pipelines/index.html
@@ -1,0 +1,524 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Семантические конвейеры интеграции и обработки данных</title>
+  <meta name="description" content="Semantic data integration and processing pipelines — определение тренда, рынок, игроки, ценность для бизнеса и пилоты." />
+  <link rel="icon" type="image/png" href="../assets/logo.png" />
+  <link rel="stylesheet" href="../assets/pdf-download.css" />
+  <style>
+    html.auth-check body{ visibility:hidden; }
+    html.auth-check.auth-ok body{ visibility:visible; }
+    :root{
+      --bg:#ffffff; --card:#ffffff; --muted:#4b5563; --text:#0b0d12;
+      --blue-1:#00A7FF; --blue-2:#007BFF; --blue-3:#0062D1; --blue-4:#0047B3; --blue-5:#CFE6FF;
+      --line:#e6eef8; --shadow: 0 10px 30px rgba(0, 80, 170, .10); --radius:18px;
+    }
+    html,body{ margin:0; padding:0; background:var(--bg); color:var(--text); font:16px/1.55 Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; }
+    .wrap{ max-width: 1120px; margin: 28px auto 64px; padding: 0 20px; }
+
+    header.hero{ background: linear-gradient(180deg, #f8fbff 0%, #ffffff 100%); padding: 24px; border: 1px solid var(--line); border-radius: var(--radius); box-shadow: var(--shadow); display:flex; gap:18px; align-items:center; flex-wrap:wrap; }
+    .hero img.logo{ height:64px; width:auto; display:block; }
+    .hero .text{ flex:1; min-width: 260px; }
+    header.hero h1{ margin:0 0 6px; letter-spacing:.2px; font-size: clamp(28px, 3.2vw, 44px); color:var(--blue-4); }
+    header.hero p.sub{ margin:0; color:var(--muted); font-size:15px; }
+
+    .tagrow{ display:flex; flex-wrap:wrap; gap:8px; margin-top:12px; }
+    .tag{ display:inline-flex; align-items:center; gap:8px; padding:8px 12px; border-radius:999px; background:#fff; border:1.6px solid var(--blue-5); font-size:13px; color:var(--blue-3); }
+
+    .stats{ display:grid; grid-template-columns: repeat(4, minmax(0,1fr)); gap:12px; margin-top:12px; width:100%; }
+    .kpi{ background:var(--card); border:1px solid var(--line); border-radius:14px; padding:14px; box-shadow: var(--shadow); }
+    .kpi .v{ font-size: clamp(18px,2.4vw,28px); font-weight:800; color:var(--blue-3); }
+    .kpi .l{ font-size:12px; color:var(--muted); margin-top:4px; }
+
+    h2{ margin: 34px 0 12px; font-size: clamp(20px,2.4vw,28px); color:var(--blue-4); }
+    section{ background:var(--card); border:1px solid var(--line); border-radius: var(--radius); padding: 20px; box-shadow: var(--shadow); }
+    .grid-2{ display:grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap:16px; }
+    .grid-3{ display:grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap:16px; }
+
+    .bullet{ margin:0; padding-left:18px; }
+    .bullet li{ margin:6px 0; }
+
+    .chips{ display:flex; flex-wrap:wrap; gap:10px; }
+    .chip{ background:#fff; border:1.8px solid var(--blue-2); color:var(--blue-3); padding:8px 10px; border-radius:10px; font-size:13px; font-weight:600; }
+    .chip:hover{ border-color: var(--blue-1); box-shadow: 0 2px 8px rgba(0, 123, 255, .12); }
+
+    .cards{ display:grid; grid-template-columns:repeat(2, minmax(0,1fr)); gap:14px; }
+    .card{ padding:14px; border-radius:14px; background:#fff; border:1px solid var(--line); box-shadow: var(--shadow); }
+    .card h4{ margin:0 0 6px; font-size:16px; color:var(--blue-3); }
+
+    .itc-layout{ display:grid; grid-template-columns:minmax(0,320px) minmax(0,1fr); gap:18px; align-items:center; }
+    .itc-spider{ margin:0; padding:16px; border-radius:14px; border:1px solid var(--line); background:#fff; box-shadow:var(--shadow); display:flex; flex-direction:column; align-items:center; gap:12px; }
+    .itc-spider svg{ width:100%; height:auto; max-width:320px; }
+    .itc-spider figcaption{ margin:0; font-size:12px; color:var(--muted); text-align:center; }
+    .itc-cards{ display:grid; grid-template-columns:repeat(2, minmax(0,1fr)); gap:12px; }
+    .itc-spider .grid-ring{ stroke:rgba(0,71,179,.25); stroke-width:1; }
+    .itc-spider .axis{ stroke:rgba(0,71,179,.3); stroke-width:1; stroke-dasharray:4 4; }
+    .itc-spider .area{ fill:rgba(0,123,255,.28); stroke:var(--blue-2); stroke-width:2; }
+    .itc-spider .dot{ fill:#fff; stroke:var(--blue-3); stroke-width:1.4; }
+    .itc-spider .axis-label{ font-size:12px; fill:var(--blue-3); font-weight:600; }
+
+    .roadmap{ position:relative; padding:16px; background:#fff; border:1px solid var(--line); border-radius:var(--radius); }
+    .roadmap-grid{ display:grid; grid-template-columns: repeat(3, 1fr); gap:16px; }
+    .phase{ position:relative; background:#fff; border:1px solid var(--line); border-radius:14px; padding:14px; box-shadow: var(--shadow); }
+    .phase h3{ margin:0 0 10px; font-size:16px; color:var(--blue-3); display:flex; align-items:center; gap:8px; }
+    .phase h3 .pill{ display:inline-block; padding:4px 8px; border-radius:999px; background:linear-gradient(90deg, var(--blue-2), var(--blue-1)); color:#fff; font-size:12px; font-weight:700; }
+    .phase ul{ margin:0; padding-left:18px; }
+    .phase li{ margin:6px 0; }
+
+    .tbl{ width:100%; border-collapse: collapse; font-size:14px; }
+    .tbl th, .tbl td{ padding:10px 12px; border-bottom:1px solid var(--line); text-align:left; }
+    .tbl th{ color:var(--muted); font-weight:600; }
+
+    .legend{ display:flex; gap:16px; flex-wrap:wrap; margin-top:8px; font-size:13px; }
+    .lg{ display:inline-flex; align-items:center; gap:8px; }
+    .c1,.c2,.c3{ width:14px; height:14px; display:inline-block; border-radius:4px; }
+    .c1{ background:var(--blue-1); }
+    .c2{ background:var(--blue-2); }
+    .c3{ background:var(--blue-4); }
+
+    details{ background:#fff; border:1px dashed var(--blue-5); padding:10px 12px; border-radius:12px; }
+    summary{ cursor:pointer; font-weight:700; color:var(--blue-3); }
+
+    .source-list{ columns: 2; gap: 18px; }
+    .source-list p{ margin:0 0 10px; }
+    .source-list a{ color: var(--blue-2); text-decoration: none; }
+    .source-list a:hover{ text-decoration: underline; }
+
+    .regional{ display:grid; grid-template-columns:1fr; gap:12px; }
+    .regional figure{ margin:0; background:#fff; border:1px solid var(--line); border-radius:var(--radius); box-shadow:var(--shadow); }
+    .regional img{ width:100%; height:auto; display:block; border-radius:var(--radius); }
+    .regional figcaption{ padding:8px 12px; font-size:12px; color:var(--muted); }
+
+    footer{ color:var(--muted); font-size:12px; margin-top: 22px; text-align:center; }
+
+    @media (max-width: 960px){
+      .itc-layout{ grid-template-columns:1fr; }
+      .itc-spider{ max-width:420px; margin:0 auto; }
+    }
+    @media (max-width: 880px){
+      .stats{ grid-template-columns: repeat(2, minmax(0,1fr)); }
+      .grid-2{ grid-template-columns:1fr; }
+      .grid-3{ grid-template-columns:1fr; }
+      .cards{ grid-template-columns:1fr; }
+      .source-list{ columns: 1; }
+      .roadmap-grid{ grid-template-columns:1fr; }
+      .itc-cards{ grid-template-columns:1fr; }
+    }
+    @media (max-width: 640px){
+      .stats{ grid-template-columns:1fr; }
+      header.hero{ padding:20px 18px; }
+      section{ padding:16px; }
+    }
+    @media (max-width: 520px){
+      .tag{ font-size:12px; }
+      .tagrow{ gap:6px; }
+    }
+    h2::after{ content:""; display:block; width:56px; height:4px; background: linear-gradient(90deg, var(--blue-2), var(--blue-1)); border-radius:2px; margin-top:8px; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <nav style="display:flex; justify-content:flex-start; margin-bottom:10px;">
+      <a href="/" style="display:inline-flex; align-items:center; gap:8px; padding:8px 12px; border:1.6px solid var(--line); border-radius:10px; text-decoration:none; color:var(--blue-3); font-weight:700; box-shadow: var(--shadow); background:#fff;">
+        <span style="font-size:18px; line-height:1">←</span>
+        <span>На главную</span>
+      </a>
+    </nav>
+
+    <header class="hero">
+      <img src="../assets/logo.png" alt="SCI logo" class="logo" />
+      <div class="text">
+        <h1>Семантические конвейеры интеграции и обработки данных</h1>
+        <p class="sub">Semantic Data Integration & Processing Pipelines • обновлено: <strong>23&nbsp;октября&nbsp;2025</strong></p>
+        <div class="tagrow">
+          <span class="tag">Hybrid Vector-SQL • ANN/HNSW</span>
+          <span class="tag">ISO&nbsp;GQL • SPARQL&nbsp;1.2 • PROV-O</span>
+          <span class="tag">Semantic Retrieval • RAG Pipelines</span>
+        </div>
+      </div>
+      <div class="stats">
+        <div class="kpi"><div class="v"><strong>2/10</strong></div><div class="l">Индекс технологичности (ITC)</div></div>
+        <div class="kpi"><div class="v"><strong>32–38%</strong></div><div class="l">CAGR 2025–2029</div></div>
+        <div class="kpi"><div class="v">TAM <strong>$3.8–4.5B</strong></div><div class="l">Оценка 2025</div></div>
+        <div class="kpi"><div class="v"><strong>0–2 года</strong></div><div class="l">Горизонт массового внедрения</div></div>
+      </div>
+    </header>
+
+    <h2>Коротко</h2>
+    <section>
+      <p><strong>Семантические конвейеры интеграции и обработки данных</strong> — специализированные хранилища и индексные движки для плотных эмбеддингов, объединяющие векторное сходство с реляционной фильтрацией, гибридными предикатами и объединёнными планами запросов. Тренд опирается на поддержку <em>ANN/HNSW</em>, смешанных векторно‑реляционных представлений, <em>ISO&nbsp;GQL</em>, <em>SPARQL&nbsp;1.2</em> и lineage по <em>W3C PROV-O</em>, чтобы ускорить RAG и семантическое извлечение в масштабах предприятия.</p>
+      <div class="grid-2">
+        <div>
+          <h3>Драйверы</h3>
+          <ul class="bullet">
+            <li>Персонализация и рекомендации на эмбеддингах с гибридной фильтрацией.</li>
+            <li>Снижение OPEX благодаря консолидации векторного поиска и SQL в одном движке.</li>
+            <li>Ускорение time-to-insight за счёт конвейеров семантического извлечения и RAG.</li>
+          </ul>
+        </div>
+        <div>
+          <h3>Статус и рынок</h3>
+          <ul class="bullet">
+            <li>Горизонт массового внедрения: <strong>0–2</strong> года.</li>
+            <li>Рост рынка <strong>32–38%</strong> CAGR (база <strong>2025</strong>).</li>
+            <li>Ключевые вендоры: Weaviate, AlloyDB for PostgreSQL, Azure AI Search, Amazon OpenSearch Service.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <h2>Индекс технологичности (ITC)</h2>
+    <section>
+      <p style="margin:0 0 16px; color:var(--muted);"><strong>Итоговый балл 2/10.</strong> Имитация R&D: рост бизнеса от продукта маловероятен при текущей зрелости.</p>
+      <div class="itc-layout">
+        <figure class="itc-spider" data-labels="SM,NV,IP,HR" data-values="30,8,6,12" data-max="100" aria-label="Спайдер-диаграмма индекса технологичности">
+          <figcaption>SM — научный моментум, NV — новизна, IP — импакт, HR — хайп/зрелость команд.</figcaption>
+        </figure>
+        <div class="itc-cards">
+          <div class="card"><h4>SM — 30</h4><p>Указывает на замедление тренда: новые исследования появляются реже, акцент смещается в инженерные оптимизации.</p></div>
+          <div class="card"><h4>NV — 8</h4><p>Сигнализирует о зрелости решений и фокусе на оптимизации издержек и bundled-сервисах.</p></div>
+          <div class="card"><h4>IP — 6</h4><p>Отражает прикладную нишевость и временной лаг накопления цитирований; важны сравнения внутри смежных дисциплин.</p></div>
+          <div class="card"><h4>HR — 12</h4><p>Говорит о лабораторной стадии и высоких барьерах входа: компетенции по гибридным планам и vector-ops дефицитны.</p></div>
+        </div>
+      </div>
+    </section>
+
+    <h2>Состав тренда: ключевые технологии</h2>
+    <section>
+      <div class="grid-3">
+        <div class="card">
+          <h4>Модели и схемы данных</h4>
+          <div class="chips">
+            <span class="chip">Плотные эмбеддинги</span><span class="chip">Метаданные атрибутов</span><span class="chip">Гибридные представления</span><span class="chip">Vector&nbsp;+&nbsp;SQL схемы</span>
+          </div>
+        </div>
+        <div class="card">
+          <h4>Языки и запросы</h4>
+          <div class="chips">
+            <span class="chip">Гибридные предикаты</span><span class="chip">Vector SQL</span><span class="chip">Объединённые планы</span><span class="chip">ISO&nbsp;GQL</span><span class="chip">SPARQL&nbsp;1.2</span>
+          </div>
+        </div>
+        <div class="card">
+          <h4>Индексы и структуры данных</h4>
+          <div class="chips">
+            <span class="chip">ANN/HNSW</span><span class="chip">Плотные vector indexes</span><span class="chip">B+-деревья</span><span class="chip">Диапазонные индексы</span><span class="chip">Обучаемые индексы</span>
+          </div>
+        </div>
+        <div class="card">
+          <h4>Хранилища и движки</h4>
+          <div class="chips">
+            <span class="chip">Векторные базы данных</span><span class="chip">Hybrid storage</span><span class="chip">Range+vector indexing</span><span class="chip">Managed DBaaS</span>
+          </div>
+        </div>
+        <div class="card">
+          <h4>Обработка и конвейеры</h4>
+          <div class="chips">
+            <span class="chip">Семантическое извлечение</span><span class="chip">RAG pipelines</span><span class="chip">Интеграция витрин</span><span class="chip">Vector ETL</span>
+          </div>
+        </div>
+        <div class="card">
+          <h4>Вычисление и исполнение</h4>
+          <div class="chips">
+            <span class="chip">Оптимизация планов</span><span class="chip">Баланс точность/задержка</span><span class="chip">Масштабирование NNS</span><span class="chip">Cost-модели</span>
+          </div>
+        </div>
+        <div class="card">
+          <h4>Операции и масштабирование</h4>
+          <div class="chips">
+            <span class="chip">Распределённое шардирование</span><span class="chip">Репликация</span><span class="chip">Управление памятью</span><span class="chip">Компрессия векторов</span><span class="chip">Горячее перестроение</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <h2>Ценность для бизнеса (ориентиры эффектов)</h2>
+    <section>
+      <div class="cards">
+        <div class="card"><h4>Персонализация и retention</h4><p>Рост конверсии и удержания за счёт рекомендаций на плотных эмбеддингах и гибридной векторно‑реляционной фильтрации.</p></div>
+        <div class="card"><h4>Снижение OPEX</h4><p>Объединение векторного поиска и SQL в одном движке сокращает расходы на поддержку отдельного стека.</p></div>
+        <div class="card"><h4>Time-to-Insight</h4><p>Конвейеры семантического извлечения и RAG ускоряют аналитические циклы благодаря объединённым планам запросов и RRF‑реранкингу.</p></div>
+        <div class="card"><h4>Оптимизация ANN-запросов</h4><p>Настройка ANN/HNSW и inline vector search уменьшает задержку и стоимость запроса.</p></div>
+        <div class="card"><h4>Масштаб и SLA</h4><p>Распределённое шардирование и репликация повышают масштабируемость и устойчивость SLA для NNS‑нагрузок.</p></div>
+        <div class="card"><h4>Качество и наблюдаемость поиска</h4><p>Метрики recall/precision и телеметрия индексов, интегрированные с витринами, улучшают контроль качества.</p></div>
+        <div class="card"><h4>Lineage и соответствие</h4><p>Внедрение PROV-O в конвейерах индексации снижает риски и упрощает соответствие регуляторным требованиям.</p></div>
+      </div>
+    </section>
+
+    <h2>Горизонт внедрения</h2>
+    <section class="roadmap">
+      <div class="roadmap-grid">
+        <div class="phase">
+          <h3><span class="pill">0–2 года</span></h3>
+          <ul class="bullet">
+            <li>Семантический поиск, рекомендации и RAG на гибридных запросах.</li>
+            <li>GA-сервисы с векторными типами, ANN/HNSW и реляционными фильтрами.</li>
+            <li>Массовые внедрения и консолидация API/SQL-расширений для vector search.</li>
+          </ul>
+        </div>
+        <div class="phase">
+          <h3><span class="pill">2–5 лет</span></h3>
+          <ul class="bullet">
+            <li>Пилоты гибридных планов и объединённого cost-моделирования.</li>
+            <li>Зрелые конвейеры индексации, lineage и DataOps-практики.</li>
+            <li>Расширение управляемых сервисов и закрепление best practices.</li>
+          </ul>
+        </div>
+        <div class="phase">
+          <h3><span class="pill">5–10 лет</span></h3>
+          <ul class="bullet">
+            <li>Обучаемые индексы и автоматическая компрессия на распределённых кластерах.</li>
+            <li>Стандартизованные интерфейсы семантического lineage и audit trail.</li>
+            <li>Усиление требований прозрачности из-за AI‑регуляций.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <h2>Размер рынка</h2>
+    <section>
+      <table class="tbl">
+        <thead><tr><th>Метрика</th><th>Оценка (2025)</th><th>Методика</th></tr></thead>
+        <tbody>
+          <tr><td>TAM</td><td><strong>$3.8–4.5B</strong></td><td>Сумма рынков векторных БД/поиска и ПО конвейеров RAG (экстраполяция 2023–2025, триангуляция Markets&amp;Markets и Grand View Research).</td></tr>
+          <tr><td>SAM</td><td><strong>$1.1–1.6B</strong></td><td>Cloud-managed развертывания для mid-market/enterprise в NA+EU, исключая on-prem/self-hosted.</td></tr>
+          <tr><td>SOM</td><td><strong>$0.25–0.50B</strong></td><td>Bottom-up: 800–1,200 enterprise аккаунтов с production RAG × $300–450k blended ARR.</td></tr>
+          <tr><td>CAGR 2025–2029</td><td><strong>≈32–38%</strong></td><td>Драйверы роста: RAG-мейнстрим, dbPaaS-бандлинг, облачная монетизация, консолидация.</td></tr>
+        </tbody>
+      </table>
+      <div class="market-chart">
+        <svg viewBox="0 0 1000 220" width="100%" height="220" role="img" aria-label="Диаграмма TAM SAM SOM">
+          <defs>
+            <linearGradient id="g1" x1="0" x2="1"><stop offset="0%" stop-color="#CFE6FF"/><stop offset="100%" stop-color="#00A7FF"/></linearGradient>
+            <linearGradient id="g2" x1="0" x2="1"><stop offset="0%" stop-color="#9BC8FF"/><stop offset="100%" stop-color="#007BFF"/></linearGradient>
+            <linearGradient id="g3" x1="0" x2="1"><stop offset="0%" stop-color="#7EB2FF"/><stop offset="100%" stop-color="#0047B3"/></linearGradient>
+          </defs>
+          <g font-size="13" font-weight="700" fill="#0b0d12">
+            <text x="20" y="60">TAM</text>
+            <text x="20" y="130">SAM</text>
+            <text x="20" y="200">SOM</text>
+          </g>
+          <g>
+            <rect x="160" y="46" width="780" height="28" rx="8" fill="url(#g1)"/>
+            <rect x="160" y="116" width="330" height="28" rx="8" fill="url(#g2)"/>
+            <rect x="160" y="186" width="140" height="28" rx="8" fill="url(#g3)"/>
+          </g>
+          <g font-size="12" font-weight="800" fill="#003F6B" text-anchor="start">
+            <text x="950" y="62">~$4.1B</text>
+            <text x="510" y="132">~$1.35B</text>
+            <text x="320" y="202">~$0.38B</text>
+          </g>
+        </svg>
+        <div class="legend">
+          <span class="lg"><span class="c1"></span> TAM (весь адресуемый рынок)</span>
+          <span class="lg"><span class="c2"></span> SAM (cloud-managed сегмент)</span>
+          <span class="lg"><span class="c3"></span> SOM (достижимый фокус 2025)</span>
+        </div>
+      </div>
+    </section>
+
+    <h2>Объём инвестиций (VC/IPO/M&A)</h2>
+    <section>
+      <ul class="bullet">
+        <li><strong>VC 2023-01 – 2025-10:</strong> ≥$196M по 4 крупным сделкам (Pinecone $100M Series B; Weaviate $50M Series B; Qdrant $28M Series A; Chroma $18M seed).</li>
+        <li><strong>Динамика:</strong> пик активности пришёлся на 2023, в 2024 — ~$73M по 8 сделкам (Crunchbase via WSJ); общий объём инвестиций векторных БД с 2022 — около $1B.</li>
+        <li><strong>Ранние стадии:</strong> посевные раунды 2024 (Lucenia $2M; Dappier $2M и др.) подтверждают спрос на RAG-конвейеры и интеграцию индексов.</li>
+        <li><strong>Фонды-лидеры:</strong> Andreessen Horowitz, Index Ventures, Battery Ventures, Spark Capital, ICONIQ Growth, Menlo Ventures, Wing VC, Quiet Capital.</li>
+        <li><strong>M&amp;A:</strong> OpenAI приобрела Rockset (2024-06, сумма не раскрыта); Snowflake купила Neeva за $185.4M (2023-05) для генпоиска в Data Cloud.</li>
+      </ul>
+    </section>
+
+    <h2>Ключевые вендоры и игроки</h2>
+    <section>
+      <div class="grid-2">
+        <div class="card">
+          <h4>Платформы/движки (OSS vector DB)</h4>
+          <ul class="bullet">
+            <li><strong>Weaviate</strong> — открытая векторная БД с гибридным поиском и официальными SDK.</li>
+            <li><strong>Milvus</strong> — векторная БД LF AI &amp; Data (статус graduated, 2021).</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h4>Облака / managed (AWS)</h4>
+          <ul class="bullet">
+            <li><strong>Amazon OpenSearch Service</strong> — managed vector search (k-NN/HNSW, knn_vector); AWS в Gartner MQ «Cloud DBMS» (2024).</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h4>Облака / managed (Google Cloud)</h4>
+          <ul class="bullet">
+            <li><strong>AlloyDB for PostgreSQL</strong> — встроенный vector search на pgvector с HNSW/ScaNN и гибридными запросами.</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h4>Облака / managed (Microsoft Azure)</h4>
+          <ul class="bullet">
+            <li><strong>Azure AI Search</strong> — векторный и гибридный поиск как managed-сервис для RAG приложений.</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h4>Инструменты / SDK для RAG</h4>
+          <ul class="bullet">
+            <li><strong>LangChain</strong> — единый интерфейс с интеграциями vector stores (PGVector, Pinecone, Qdrant, Weaviate и др.).</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h4>Стандартизация</h4>
+          <ul class="bullet">
+            <li><strong>ISO&nbsp;GQL (ISO/IEC 39075:2024)</strong> — язык запросов к property graphs.</li>
+            <li><strong>W3C SPARQL 1.2</strong> — комплект спецификаций (Working Draft, 2024) для протокола и языка SPARQL.</li>
+            <li><strong>W3C PROV-O</strong> — онтология lineage и provenance для конвейеров индексации.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <h2>Гипотезы для пилотов</h2>
+    <section>
+      <div class="grid-2">
+        <details open>
+          <summary>Гибридный семантический поиск и рекомендации в каталоге</summary>
+          <p>Цель — рост выручки и удержания; подход — смешанные векторно-реляционные представления, гибридные предикаты, RRF-слияние, ANN (HNSW) с фильтрами; данные — каталог, атрибуты, журналы поиска/кликов; метрики — рост NDCG@10 и CTR при соблюдении p95 SLA; длительность — 8–10 недель; go/no-go — прирост CTR и NDCG без деградации задержки и фильтров.</p>
+        </details>
+        <details>
+          <summary>RAG для службы поддержки и базы знаний</summary>
+          <p>Цель — сокращение времени ответа и рост удовлетворённости; подход — конвейер семантического извлечения и RAG с оптимизацией top-K и reranking, метаданными атрибутов и фильтрами; данные — база знаний, тикеты, FAQ; метрики — достижение целевого groundedness/faithfulness и снижение эскалаций; длительность — 6–9 недель; go/no-go — устойчивое снижение эскалаций при прохождении порога groundedness.</p>
+        </details>
+        <details>
+          <summary>Снижение TCO хранения эмбеддингов</summary>
+          <p>Цель — уменьшение OPEX; подход — offload графов векторов в объектное хранилище с PQ/квантованием, диапазонными и векторными индексами; данные — десятки миллионов эмбеддингов и метаданные; метрики — снижение стоимости на 1 млн векторов при сохранении recall@K и p95 SLA; длительность — 4–6 недель; go/no-go — экономия без потери точности и SLA.</p>
+        </details>
+        <details>
+          <summary>Оптимизация параметров ANN и гибридных планов</summary>
+          <p>Цель — рост пропускной способности без потери качества; подход — настройка HNSW/DiskANN/IVF-PQ, объединённые планы (векторы + SQL), батчинг, кэширование и профилирование; данные — репрезентативный корпус запросов и эмбеддинги; метрики — целевой профиль recall–QPS и p95 SLA; длительность — 5–7 недель; go/no-go — подтверждённый выигрыш QPS при неизменном recall и SLA.</p>
+        </details>
+        <details>
+          <summary>Линейность и аудит конвейера эмбеддингов</summary>
+          <p>Цель — снижение рисков и подготовка к аудитам; подход — внедрение OpenLineage/PROV-O, контроль доступа к витринам и индексам, проверки PII/утечек; данные — источники, этапы извлечения, журналы доступа; метрики — покрытие lineage по критическим узлам, прохождение проверок и сокращение времени ответа на аудит; длительность — 6–8 недель; go/no-go — полный lineage для приоритетных потоков и отсутствие критических замечаний.</p>
+        </details>
+        <details>
+          <summary>Бесперебойное обслуживание при росте нагрузок</summary>
+          <p>Цель — стабильность SLA и масштабирование без простоев; подход — распределённое шардирование и репликация, горячее перестроение графов, управление TTL/кэшем и балансировкой; данные — продовые индексы с реальным трафиком; метрики — отсутствие деградации пользовательских метрик и ошибок поиска, время перестроения в согласованном окне; длительность — 6–8 недель; go/no-go — перестроение без видимой деградации SLA и качества выдачи.</p>
+        </details>
+      </div>
+    </section>
+
+    <h2>Источники</h2>
+    <section>
+      <div class="source-list">
+        <p><a href="https://www.forrester.com/report/forresters-guide-to-retrieval-augmented-generation-part-one/RES181692" target="_blank" rel="noopener">Forrester (2024) — Guide to Retrieval Augmented Generation</a></p>
+        <p><a href="https://www.forrester.com/blogs/unleashing-the-first-forrester-wave-for-vector-databases/" target="_blank" rel="noopener">Forrester (2024) — First Wave for Vector Databases</a></p>
+        <p><a href="https://www.gartner.com/en/newsroom/press-releases/2025-06-02-gartner-predicts-by-2028-80-percent-of-genai-business-apps-will-be-developed-on-existing-data-management-platforms" target="_blank" rel="noopener">Gartner (2025) — GenAI business apps на существующих платформах</a></p>
+        <p><a href="https://www.gartner.com/en/documents/6700234" target="_blank" rel="noopener">Gartner (2024) — Market Guide for Vector Databases</a></p>
+        <p><a href="https://www.gartner.com/en/documents/6027835" target="_blank" rel="noopener">Gartner (2023) — Emerging Tech Impact Radar: AI in Data Management</a></p>
+        <p><a href="https://www.iso.org/standard/76120.html" target="_blank" rel="noopener">ISO (2019) — ISO 24617-6:2014/Amd 1:2019</a></p>
+        <p><a href="https://www.sec.gov/Archives/edgar/data/1640147/000164014724000101/snow-20240131.htm" target="_blank" rel="noopener">SEC EDGAR (2024) — Snowflake Form 10-K</a></p>
+        <p><a href="https://www.thomsonreuters.com/en/press-releases/2023/november/thomson-reuters-launches-generative-ai-powered-solutions-to-transform-how-legal-professionals-work" target="_blank" rel="noopener">Thomson Reuters (2023) — GenAI solutions for legal</a></p>
+        <p><a href="https://www.thomsonreuters.com/en/press-releases/2024/july/thomson-reuters-launches-its-latest-generative-ai-skill-in-westlaw-precision-with-cocounsel" target="_blank" rel="noopener">Thomson Reuters (2024) — GenAI skill in Westlaw Precision</a></p>
+        <p><a href="https://www.w3.org/TR/prov-o/" target="_blank" rel="noopener">W3C (2013) — PROV-O: The PROV Ontology</a></p>
+        <p><a href="https://www.w3.org/TR/prov-overview/" target="_blank" rel="noopener">W3C (2013) — PROV Overview</a></p>
+        <p><a href="https://www.w3.org/TR/2024/WD-sparql12-update-20241025/" target="_blank" rel="noopener">W3C (2024) — SPARQL 1.2 Update</a></p>
+      </div>
+    </section>
+
+    <footer>© 2025 • SCI • Главная по технологиям KG</footer>
+  </div>
+<script>
+  (function(){
+    const SVG_NS = 'http://www.w3.org/2000/svg';
+    function renderSpiders(){
+      document.querySelectorAll('.itc-spider').forEach(container=>{
+        const labels = (container.dataset.labels || '').split(',').map(s=>s.trim()).filter(Boolean);
+        const raw = (container.dataset.values || '').split(',').map(s=> Number(s.trim()));
+        if(!labels.length) return;
+        const max = Number(container.dataset.max || 100) || 100;
+        const levels = Number(container.dataset.levels || 5) || 5;
+        const existing = container.querySelector('svg');
+        if(existing){ existing.remove(); }
+
+        const svg = document.createElementNS(SVG_NS, 'svg');
+        svg.setAttribute('viewBox','0 0 320 320');
+        svg.setAttribute('width','100%');
+        svg.setAttribute('height','100%');
+        svg.setAttribute('focusable','false');
+
+        const center = 160;
+        const radius = 120;
+
+        const toPoint = (ratio, idx)=>{
+          const angle = -Math.PI/2 + idx * (Math.PI*2/labels.length);
+          const r = radius * ratio;
+          return {
+            x: center + Math.cos(angle) * r,
+            y: center + Math.sin(angle) * r
+          };
+        };
+
+        const gridGroup = document.createElementNS(SVG_NS,'g');
+        for(let level=1; level<=levels; level++){
+          const pts = labels.map((_, idx)=> toPoint(level/levels, idx));
+          const polygon = document.createElementNS(SVG_NS,'polygon');
+          polygon.setAttribute('points', pts.map(p=> `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' '));
+          polygon.setAttribute('class','grid-ring');
+          polygon.setAttribute('fill', level % 2 === 0 ? 'rgba(0,123,255,.05)' : 'rgba(0,123,255,.1)');
+          gridGroup.appendChild(polygon);
+        }
+        svg.appendChild(gridGroup);
+
+        const axisGroup = document.createElementNS(SVG_NS,'g');
+        labels.forEach((label, idx)=>{
+          const end = toPoint(1, idx);
+          const axis = document.createElementNS(SVG_NS,'line');
+          axis.setAttribute('x1', center); axis.setAttribute('y1', center);
+          axis.setAttribute('x2', end.x); axis.setAttribute('y2', end.y);
+          axis.setAttribute('class','axis');
+          axisGroup.appendChild(axis);
+
+          const labelPoint = toPoint(1.12, idx);
+          const text = document.createElementNS(SVG_NS,'text');
+          text.textContent = label;
+          text.setAttribute('x', labelPoint.x);
+          text.setAttribute('y', labelPoint.y);
+          text.setAttribute('class','axis-label');
+          const anchor = labelPoint.x < center - 5 ? 'end' : (labelPoint.x > center + 5 ? 'start' : 'middle');
+          text.setAttribute('text-anchor', anchor);
+          axisGroup.appendChild(text);
+        });
+        svg.appendChild(axisGroup);
+
+        const valuePoints = labels.map((_, idx)=>{
+          const value = Math.max(0, Math.min(raw[idx] ?? 0, max));
+          return toPoint(value / max, idx);
+        });
+
+        const areaGroup = document.createElementNS(SVG_NS,'g');
+        const area = document.createElementNS(SVG_NS,'polygon');
+        area.setAttribute('points', valuePoints.map(p=> `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' '));
+        area.setAttribute('class','area');
+        area.setAttribute('fill', 'rgba(0,123,255,.28)');
+        areaGroup.appendChild(area);
+
+        valuePoints.forEach(pt=>{
+          const dot = document.createElementNS(SVG_NS,'circle');
+          dot.setAttribute('cx', pt.x); dot.setAttribute('cy', pt.y); dot.setAttribute('r', 4);
+          dot.setAttribute('class','dot');
+          areaGroup.appendChild(dot);
+        });
+
+        svg.appendChild(areaGroup);
+        container.insertBefore(svg, container.firstChild);
+      });
+    }
+
+    renderSpiders();
+    let resizeTimer;
+    window.addEventListener('resize', ()=>{
+      clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(renderSpiders, 160);
+    });
+  })();
+</script>
+<script src="../assets/pdf-download.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new landing page for semantic data integration and processing pipelines with market, ITC and pilot guidance
- extend the radar dataset with the semantic pipelines entry so it appears on the homepage board and radar

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68fb8fa17b2c83338109a080ddad4b48