### PR TITLE
Reorder regional activity sections on technology pages

### DIFF
--- a/ekg/index.html
+++ b/ekg/index.html
@@ -249,6 +249,14 @@
       </div>
     </section>
 
+    <h2>Региональная активность</h2>
+    <section class="regional">
+      <figure class="regional-figure">
+        <img src="../assets/regional-analytics.png" alt="Региональная аналитика внедрений платформ корпоративных графов знаний" loading="lazy" />
+        <figcaption>Региональная аналитика (источник: внутренний анализ, 2025)</figcaption>
+      </figure>
+    </section>
+
     <h2>Горизонт внедрения</h2>
     <section class="roadmap">
       <div class="roadmap-grid">
@@ -365,14 +373,6 @@
           </ul>
         </div>
       </div>
-    </section>
-
-    <h2>Региональное развитие решений</h2>
-    <section class="regional">
-      <figure class="regional-figure">
-        <img src="../assets/regional-analytics.png" alt="Региональная аналитика внедрений платформ корпоративных графов знаний" loading="lazy" />
-        <figcaption>Региональная аналитика (источник: внутренний анализ, 2025)</figcaption>
-      </figure>
     </section>
 
     <h2>Гипотезы для пилотов</h2>

--- a/streaming-rt/index.html
+++ b/streaming-rt/index.html
@@ -247,6 +247,14 @@
       </div>
     </section>
 
+    <h2>Региональная активность</h2>
+    <section class="regional">
+      <figure>
+        <img src="../assets/regional-analytics.png" alt="Карта публикаций по потоковой обработке событий" loading="lazy" />
+        <figcaption>Основные публикации и внедрения сосредоточены в США, странах ЕС, Великобритании и Азии; усиливается внимание к ЕС (Германия) и США.</figcaption>
+      </figure>
+    </section>
+
     <h2>Горизонт внедрения</h2>
     <section class="roadmap">
       <div class="roadmap-grid">
@@ -401,14 +409,6 @@
         <summary>Линейдж событий и аудит</summary>
         <p>OpenLineage/Marquez интеграция для Flink/Kafka/коннекторов, привязка к схемам и версиям. Метрики: покрытие lineage, время поиска корневой причины, полнота атрибутов. Срок: 5–7 недель.</p>
       </details>
-    </section>
-
-    <h2>Региональная активность</h2>
-    <section class="regional">
-      <figure>
-        <img src="../assets/regional-analytics.png" alt="Карта публикаций по потоковой обработке событий" loading="lazy" />
-        <figcaption>Основные публикации и внедрения сосредоточены в США, странах ЕС, Великобритании и Азии; усиливается внимание к ЕС (Германия) и США.</figcaption>
-      </figure>
     </section>
 
     <h2>Публикации и отчёты</h2>

--- a/streaming/index.html
+++ b/streaming/index.html
@@ -238,6 +238,14 @@
       </div>
     </section>
 
+    <h2>Региональная активность</h2>
+    <section class="regional">
+      <figure>
+        <img src="../assets/regional-analytics.png" alt="Карта публикаций по потоковой обработке событий" loading="lazy" />
+        <figcaption>Основные публикации и внедрения сосредоточены в США, странах ЕС, Великобритании и Азии; усиливается внимание к ЕС (Германия) и США.</figcaption>
+      </figure>
+    </section>
+
     <h2>Горизонт внедрения</h2>
     <section class="roadmap">
       <div class="roadmap-grid">
@@ -392,14 +400,6 @@
         <summary>Линейдж событий и аудит</summary>
         <p>OpenLineage/Marquez интеграция для Flink/Kafka/коннекторов, привязка к схемам и версиям. Метрики: покрытие lineage, время поиска корневой причины, полнота атрибутов. Срок: 5–7 недель.</p>
       </details>
-    </section>
-
-    <h2>Региональная активность</h2>
-    <section class="regional">
-      <figure>
-        <img src="../assets/regional-analytics.png" alt="Карта публикаций по потоковой обработке событий" loading="lazy" />
-        <figcaption>Основные публикации и внедрения сосредоточены в США, странах ЕС, Великобритании и Азии; усиливается внимание к ЕС (Германия) и США.</figcaption>
-      </figure>
     </section>
 
     <h2>Публикации и отчёты</h2>


### PR DESCRIPTION
## Summary
- move the "Региональная активность" block immediately after the business value section on streaming technology pages
- align the knowledge graph page with the same regional activity placement and naming

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68fb8fbf935083338a70bc5be5af10a7