### PR TITLE
Fix PDF pagination to start each block on a new page

### DIFF
--- a/assets/pdf-download.css
+++ b/assets/pdf-download.css
@@ -56,6 +56,24 @@
     box-shadow:none !important;
     background:#fff !important;
   }
+  .wrap > header.hero{
+    page-break-before:auto;
+    break-before:auto;
+    page-break-after:always;
+    break-after:page;
+  }
+  .wrap > h2{
+    page-break-before:always;
+    break-before:page;
+  }
+  .wrap > h2:first-of-type{
+    page-break-before:auto;
+    break-before:auto;
+  }
+  .wrap > h2 + section{
+    page-break-before:avoid;
+    break-before:avoid;
+  }
   header, section, footer, nav, .radar-wrap, .board, .hero, .stats, .cards, .itc-card, .roadmap, .phase, .card, .kpi, .radar{
     page-break-inside:avoid;
     break-inside:avoid;


### PR DESCRIPTION
## Summary
- add print styles so the hero and each content block begin on a fresh PDF page
- keep section headings attached to their content when printing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fba29950d4833397065c22863a575e