### PR TITLE
Improve search fallback when no technologies match all terms

### DIFF
--- a/index.html
+++ b/index.html
@@ -444,13 +444,20 @@ function setupSearch(){
       updateClearState();
       return;
     }
-    const res = base.filter(t=> {
-      const bag = [t.name, t.slug, t.ring, ringLabelsById[t.ring], ...(t.keys||[])]
-        .filter(Boolean)
-        .map(norm)
-        .join(' ');
+    const makeBag = (t)=> [t.name, t.slug, t.ring, ringLabelsById[t.ring], ...(t.keys||[])]
+      .filter(Boolean)
+      .map(norm)
+      .join(' ');
+    let res = base.filter(t=> {
+      const bag = makeBag(t);
       return terms.every(term => bag.includes(term));
     });
+    if(!res.length){
+      res = base.filter(t=> {
+        const bag = makeBag(t);
+        return terms.some(term => bag.includes(term));
+      });
+    }
     renderBoard(res);
     renderRadar(res);
     updateClearState();


### PR DESCRIPTION
## Summary
- add a helper to normalize searchable text for each technology
- keep the existing "all terms" search but fall back to "any term" when it yields no results

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fba025ca288333b9862190a4f7478f