### PR TITLE
Restore missing technology cards on the radar

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,6 +206,15 @@ const technologies = [
     angle: 40
   },
   {
+    id:'semantic-pipelines',
+    slug:'semantic-pipelines',
+    name:'Семантические конвейеры интеграции и обработки данных',
+    keys:['Hybrid Vector-SQL • ANN/HNSW','ISO GQL • SPARQL 1.2 • PROV-O','Semantic Retrieval • RAG Pipelines'],
+    link: makeLink('semantic-pipelines'),
+    ring:'pilot',
+    angle: 100
+  },
+  {
     id:'streaming-platforms',
     slug:'streaming',
     name:'Распределённые платформы потоковой передачи событий',
@@ -231,6 +240,15 @@ const technologies = [
     link: makeLink('blockchain-governance'),
     ring:'pilot',
     angle: 310
+  },
+  {
+    id:'disaggregated-storage',
+    slug:'disaggregated-storage',
+    name:'Дезагрегированные распределённые архитектуры хранения',
+    keys:['HL7 FHIR R4/R5','OMOP CDM','FHIR Bulk Data $export','Terminology Services','SMART on FHIR / OAuth 2.0','Parquet & BigQuery'],
+    link: makeLink('disaggregated-storage'),
+    ring:'observe',
+    angle: 350
   }
 ];
 


### PR DESCRIPTION
## Summary
- add the semantic pipelines technology back to the radar dataset so it appears on the main board
- restore the disaggregated storage technology card so it is discoverable from the homepage

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68fbc1de264c8333b44d0429d46f0754