### PR TITLE
Fix blank page before ITC section in PDF printouts

### DIFF
--- a/assets/pdf-download.css
+++ b/assets/pdf-download.css
@@ -99,6 +99,10 @@
     page-break-before:auto;
     break-before:auto;
   }
+  .wrap > header.hero + h2{
+    page-break-before:auto !important;
+    break-before:auto !important;
+  }
   .wrap > h2 + section{
     page-break-before:avoid;
     break-before:avoid;


### PR DESCRIPTION
## Summary
- prevent the first section heading after the hero block from forcing a duplicate page break when printing to PDF, eliminating empty pages before the ITC content

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fc916136a48333bdcb461a3abb923f