### PR TITLE
Rebuild ITC sections to eliminate PDF gaps

### DIFF
--- a/assets/pdf-download.css
+++ b/assets/pdf-download.css
@@ -99,11 +99,23 @@
     page-break-before:auto;
     break-before:auto;
   }
+  .wrap > header.hero + h2{
+    page-break-before:auto !important;
+    break-before:auto !important;
+  }
   .wrap > h2 + section{
     page-break-before:avoid;
     break-before:avoid;
   }
-  header, section, footer, nav, .radar-wrap, .board, .hero, .stats, .cards, .itc-card, .roadmap, .phase, .card, .kpi, .radar{
+  .wrap > section.itc{
+    page-break-before:auto !important;
+    break-before:auto !important;
+  }
+  .wrap > section.itc h2{
+    page-break-after:avoid;
+    break-after:avoid;
+  }
+  header, section, footer, nav, .radar-wrap, .board, .hero, .stats, .cards, .itc-card, .itc-panel, .roadmap, .phase, .card, .kpi, .radar{
     page-break-inside:avoid;
     break-inside:avoid;
   }

--- a/blockchain-governance/index.html
+++ b/blockchain-governance/index.html
@@ -42,6 +42,8 @@
       background: linear-gradient(90deg, var(--blue-2), var(--blue-1)) no-repeat left bottom / 56px 4px;
     }
     section{ background:var(--card); border:1px solid var(--line); border-radius: var(--radius); padding: 20px; box-shadow: var(--shadow); }
+    section.itc{ background:none; border:none; box-shadow:none; padding:0; }
+    .itc-panel{ background:var(--card); border:1px solid var(--line); border-radius:var(--radius); padding:20px; box-shadow:var(--shadow); }
     .grid-2{ display:grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap:16px; }
     .grid-3{ display:grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap:16px; }
 
@@ -125,6 +127,7 @@
       .stats{ grid-template-columns:1fr; }
       header.hero{ padding:20px 18px; }
       section{ padding:16px; }
+      .itc-panel{ padding:16px; }
     }
     @media (max-width: 520px){
       .tag{ font-size:12px; }
@@ -155,17 +158,19 @@
       </div>
     </header>
 
-    <h2>Индекс технологичности (ITC)</h2>
-    <section>
-      <div class="itc-layout">
-        <figure class="itc-spider" data-labels="SM,NV,IP,HR" data-values="40,30,4,8" data-max="100" aria-label="Спайдер-диаграмма индекса технологичности">
-          <figcaption>SM — научный моментум, NV — новизна, IP — импакт, HR — готовность команд.</figcaption>
-        </figure>
-        <div class="itc-cards">
-          <div class="card"><h4>SM — 40</h4><p>Научный моментум замедляется: исследования концентрируются на стандартах SPARQL&nbsp;1.2 и графовом lineage.</p></div>
-          <div class="card"><h4>NV — 30</h4><p>Новизна умеренная: акцент смещается в оптимизацию издержек и интеграцию с управляемыми леджерами.</p></div>
-          <div class="card"><h4>IP — 4</h4><p>Импакт нишевый: отрасли BFSI/healthcare пилотируют решения, но масштабных референсов пока мало.</p></div>
-          <div class="card"><h4>HR — 8</h4><p>Высокие барьеры входа: требуются компетенции по онтологиям, OBDA и безопасным блокчейн-интеграциям.</p></div>
+    <section class="itc">
+      <h2>Индекс технологичности (ITC)</h2>
+      <div class="itc-panel">
+        <div class="itc-layout">
+          <figure class="itc-spider" data-labels="SM,NV,IP,HR" data-values="40,30,4,8" data-max="100" aria-label="Спайдер-диаграмма индекса технологичности">
+            <figcaption>SM — научный моментум, NV — новизна, IP — импакт, HR — готовность команд.</figcaption>
+          </figure>
+          <div class="itc-cards">
+            <div class="card"><h4>SM — 40</h4><p>Научный моментум замедляется: исследования концентрируются на стандартах SPARQL&nbsp;1.2 и графовом lineage.</p></div>
+            <div class="card"><h4>NV — 30</h4><p>Новизна умеренная: акцент смещается в оптимизацию издержек и интеграцию с управляемыми леджерами.</p></div>
+            <div class="card"><h4>IP — 4</h4><p>Импакт нишевый: отрасли BFSI/healthcare пилотируют решения, но масштабных референсов пока мало.</p></div>
+            <div class="card"><h4>HR — 8</h4><p>Высокие барьеры входа: требуются компетенции по онтологиям, OBDA и безопасным блокчейн-интеграциям.</p></div>
+          </div>
         </div>
       </div>
     </section>

--- a/blockchain/index.html
+++ b/blockchain/index.html
@@ -42,6 +42,8 @@
       background:linear-gradient(90deg,var(--blue-2),var(--blue-1)) no-repeat left bottom / 56px 4px;
     }
     section{ background:var(--card); border:1px solid var(--line); border-radius:var(--radius); padding:20px; box-shadow:var(--shadow); }
+    section.itc{ background:none; border:none; box-shadow:none; padding:0; }
+    .itc-panel{ background:var(--card); border:1px solid var(--line); border-radius:var(--radius); padding:20px; box-shadow:var(--shadow); }
 
     .grid-2{ display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:16px; }
     .grid-3{ display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:16px; }
@@ -129,28 +131,30 @@
       </div>
     </header>
 
-    <h2>Индекс технологичности (ITC)</h2>
-    <section>
-      <div class="itc-layout">
-        <figure class="itc-spider" data-labels="SM,NV,IP,HR" data-values="52,38,24,36" data-max="100" aria-label="Спайдер-диаграмма индекса технологичности">
-          <figcaption>SM — научный моментум, NV — новизна, IP — импакт, HR — готовность команд.</figcaption>
-        </figure>
-        <div class="itc-cards">
-          <div class="card">
-            <h3>SM — 52</h3>
-            <p>Устойчивый научный моментум: активные исследования в области конфиденциальных вычислений, CBDC и cross-chain interoperability.</p>
-          </div>
-          <div class="card">
-            <h3>NV — 38</h3>
-            <p>Новизна выше средней: внедряются ZKP, MPC и регулируемые токенизационные модели, но ядро платформ стабилизируется.</p>
-          </div>
-          <div class="card">
-            <h3>IP — 24</h3>
-            <p>Импакт растёт за счёт масштабируемых консорциумов и пилотов в финансах, логистике и энергетике, но ещё ограничен регуляторикой.</p>
-          </div>
-          <div class="card">
-            <h3>HR — 36</h3>
-            <p>Операционная готовность умеренная: зрелые DevSecOps-пайплайны, но дефицит специалистов по governance и privacy-инженерии.</p>
+    <section class="itc">
+      <h2>Индекс технологичности (ITC)</h2>
+      <div class="itc-panel">
+        <div class="itc-layout">
+          <figure class="itc-spider" data-labels="SM,NV,IP,HR" data-values="52,38,24,36" data-max="100" aria-label="Спайдер-диаграмма индекса технологичности">
+            <figcaption>SM — научный моментум, NV — новизна, IP — импакт, HR — готовность команд.</figcaption>
+          </figure>
+          <div class="itc-cards">
+            <div class="card">
+              <h3>SM — 52</h3>
+              <p>Устойчивый научный моментум: активные исследования в области конфиденциальных вычислений, CBDC и cross-chain interoperability.</p>
+            </div>
+            <div class="card">
+              <h3>NV — 38</h3>
+              <p>Новизна выше средней: внедряются ZKP, MPC и регулируемые токенизационные модели, но ядро платформ стабилизируется.</p>
+            </div>
+            <div class="card">
+              <h3>IP — 24</h3>
+              <p>Импакт растёт за счёт масштабируемых консорциумов и пилотов в финансах, логистике и энергетике, но ещё ограничен регуляторикой.</p>
+            </div>
+            <div class="card">
+              <h3>HR — 36</h3>
+              <p>Операционная готовность умеренная: зрелые DevSecOps-пайплайны, но дефицит специалистов по governance и privacy-инженерии.</p>
+            </div>
           </div>
         </div>
       </div>

--- a/disaggregated-storage/index.html
+++ b/disaggregated-storage/index.html
@@ -42,6 +42,8 @@
       background: linear-gradient(90deg, var(--blue-2), var(--blue-1)) no-repeat left bottom / 56px 4px;
     }
     section{ background:var(--card); border:1px solid var(--line); border-radius: var(--radius); padding: 20px; box-shadow: var(--shadow); }
+    section.itc{ background:none; border:none; box-shadow:none; padding:0; }
+    .itc-panel{ background:var(--card); border:1px solid var(--line); border-radius:var(--radius); padding:20px; box-shadow:var(--shadow); }
     .grid-2{ display:grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap:16px; }
     .grid-3{ display:grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap:16px; }
 
@@ -122,6 +124,7 @@
       .stats{ grid-template-columns:1fr; }
       header.hero{ padding:20px 18px; }
       section{ padding:16px; }
+      .itc-panel{ padding:16px; }
     }
     @media (max-width: 520px){
       .tag{ font-size:12px; }
@@ -155,17 +158,19 @@
       </div>
     </header>
 
-    <h2>Индекс технологичности (ITC)</h2>
-    <section>
-      <div class="itc-layout">
-        <figure class="itc-spider" data-labels="SM,NV,IP,HR" data-values="32,20,8,18" data-max="100" aria-label="Спайдер-диаграмма индекса технологичности">
-          <figcaption>SM — научный моментум, NV — новизна, IP — импакт, HR — готовность команд.</figcaption>
-        </figure>
-        <div class="itc-cards">
-          <div class="card"><h4>SM — 32</h4><p>Научный моментум смещается к операционным вопросам: публикации фокусируются на стандартных профилях и совместимости.</p></div>
-          <div class="card"><h4>NV — 20</h4><p>Новизна ограничена: ключевые инновации — в оптимизации стоимости владения, автоматизации терминологий и security-by-design.</p></div>
-          <div class="card"><h4>IP — 8</h4><p>Импакт пока нишевый: отраслевые референсы появляются в клинических сетях и страховании, но остаются точечными.</p></div>
-          <div class="card"><h4>HR — 18</h4><p>Командам не хватает экспертов по FHIR/OMOP и атрибутному доступу; зрелые процессы только в крупных госпиталях и payers.</p></div>
+    <section class="itc">
+      <h2>Индекс технологичности (ITC)</h2>
+      <div class="itc-panel">
+        <div class="itc-layout">
+          <figure class="itc-spider" data-labels="SM,NV,IP,HR" data-values="32,20,8,18" data-max="100" aria-label="Спайдер-диаграмма индекса технологичности">
+            <figcaption>SM — научный моментум, NV — новизна, IP — импакт, HR — готовность команд.</figcaption>
+          </figure>
+          <div class="itc-cards">
+            <div class="card"><h4>SM — 32</h4><p>Научный моментум смещается к операционным вопросам: публикации фокусируются на стандартных профилях и совместимости.</p></div>
+            <div class="card"><h4>NV — 20</h4><p>Новизна ограничена: ключевые инновации — в оптимизации стоимости владения, автоматизации терминологий и security-by-design.</p></div>
+            <div class="card"><h4>IP — 8</h4><p>Импакт пока нишевый: отраслевые референсы появляются в клинических сетях и страховании, но остаются точечными.</p></div>
+            <div class="card"><h4>HR — 18</h4><p>Командам не хватает экспертов по FHIR/OMOP и атрибутному доступу; зрелые процессы только в крупных госпиталях и payers.</p></div>
+          </div>
         </div>
       </div>
     </section>

--- a/semantic-pipelines/index.html
+++ b/semantic-pipelines/index.html
@@ -42,6 +42,8 @@
       background: linear-gradient(90deg, var(--blue-2), var(--blue-1)) no-repeat left bottom / 56px 4px;
     }
     section{ background:var(--card); border:1px solid var(--line); border-radius: var(--radius); padding: 20px; box-shadow: var(--shadow); }
+    section.itc{ background:none; border:none; box-shadow:none; padding:0; }
+    .itc-panel{ background:var(--card); border:1px solid var(--line); border-radius:var(--radius); padding:20px; box-shadow:var(--shadow); }
     .grid-2{ display:grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap:16px; }
     .grid-3{ display:grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap:16px; }
 
@@ -125,6 +127,7 @@
       .stats{ grid-template-columns:1fr; }
       header.hero{ padding:20px 18px; }
       section{ padding:16px; }
+      .itc-panel{ padding:16px; }
     }
     @media (max-width: 520px){
       .tag{ font-size:12px; }
@@ -155,17 +158,19 @@
       </div>
     </header>
 
-    <h2>Индекс технологичности (ITC)</h2>
-    <section>
-      <div class="itc-layout">
-        <figure class="itc-spider" data-labels="SM,NV,IP,HR" data-values="44,28,6,16" data-max="100" aria-label="Спайдер-диаграмма индекса технологичности">
-          <figcaption>SM — научный моментум, NV — новизна, IP — импакт, HR — готовность команд.</figcaption>
-        </figure>
-        <div class="itc-cards">
-          <div class="card"><h4>SM — 44</h4><p>Стабильный поток публикаций по гибридным векторно-реляционным запросам, ISO&nbsp;GQL и PROV-O.</p></div>
-          <div class="card"><h4>NV — 28</h4><p>Новизна средняя: вендоры закрепляют гибридные движки и автоматизацию семантических моделей.</p></div>
-          <div class="card"><h4>IP — 6</h4><p>Импакт растёт медленно: крупные референсы появляются в BFSI и телекомах, но остаются штучными.</p></div>
-          <div class="card"><h4>HR — 16</h4><p>Операционная готовность ограничена: нужны специалисты по онтологиям, ISO&nbsp;GQL и управлению эмбеддингами.</p></div>
+    <section class="itc">
+      <h2>Индекс технологичности (ITC)</h2>
+      <div class="itc-panel">
+        <div class="itc-layout">
+          <figure class="itc-spider" data-labels="SM,NV,IP,HR" data-values="44,28,6,16" data-max="100" aria-label="Спайдер-диаграмма индекса технологичности">
+            <figcaption>SM — научный моментум, NV — новизна, IP — импакт, HR — готовность команд.</figcaption>
+          </figure>
+          <div class="itc-cards">
+            <div class="card"><h4>SM — 44</h4><p>Стабильный поток публикаций по гибридным векторно-реляционным запросам, ISO&nbsp;GQL и PROV-O.</p></div>
+            <div class="card"><h4>NV — 28</h4><p>Новизна средняя: вендоры закрепляют гибридные движки и автоматизацию семантических моделей.</p></div>
+            <div class="card"><h4>IP — 6</h4><p>Импакт растёт медленно: крупные референсы появляются в BFSI и телекомах, но остаются штучными.</p></div>
+            <div class="card"><h4>HR — 16</h4><p>Операционная готовность ограничена: нужны специалисты по онтологиям, ISO&nbsp;GQL и управлению эмбеддингами.</p></div>
+          </div>
         </div>
       </div>
     </section>

--- a/streaming-rt/index.html
+++ b/streaming-rt/index.html
@@ -42,6 +42,8 @@
       background: linear-gradient(90deg, var(--blue-2), var(--blue-1)) no-repeat left bottom / 56px 4px;
     }
     section{ background:var(--card); border:1px solid var(--line); border-radius: var(--radius); padding: 20px; box-shadow: var(--shadow); }
+    section.itc{ background:none; border:none; box-shadow:none; padding:0; }
+    .itc-panel{ background:var(--card); border:1px solid var(--line); border-radius:var(--radius); padding:20px; box-shadow:var(--shadow); }
     .grid-2{ display:grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap:16px; }
     .grid-3{ display:grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap:16px; }
 
@@ -125,6 +127,7 @@
       .stats{ grid-template-columns:1fr; }
       header.hero{ padding:20px 18px; }
       section{ padding:16px; }
+      .itc-panel{ padding:16px; }
     }
     @media (max-width: 520px){
       .tag{ font-size:12px; }
@@ -156,17 +159,19 @@
       <p class="itc-note">Итоговый балл: <strong>3/10</strong> (Эпизодическая активность. Первые работы, слабая новизна, TR почти нулевая. Рост — едва заметен.)</p>
     </header>
 
-    <h2>Индекс технологичности (ITC)</h2>
-    <section>
-      <div class="itc-layout">
-        <figure class="itc-spider" data-labels="SM,NV,IP,HR" data-values="42,20,2,8" data-max="100" aria-label="Спайдер-диаграмма индекса технологичности">
-          <figcaption>SM — научный моментум, NV — новизна, IP — импакт, HR — готовность команд.</figcaption>
-        </figure>
-        <div class="itc-cards">
-          <div class="card"><h4>SM — 42</h4><p>Научный моментум замедляется: публикации фокусируются на оптимизации latency, observability и безопасности.</p></div>
-          <div class="card"><h4>NV — 20</h4><p>Новизна ограничена: основной фокус на управляемых сервисах, BYOC и снижении стоимости владения.</p></div>
-          <div class="card"><h4>IP — 2</h4><p>Импакт пока нишевый: требуется больше доказанных кейсов в высокорегулируемых индустриях.</p></div>
-          <div class="card"><h4>HR — 8</h4><p>Высокие барьеры: дефицит экспертов по stateful streams, exactly-once и платформенной надёжности.</p></div>
+    <section class="itc">
+      <h2>Индекс технологичности (ITC)</h2>
+      <div class="itc-panel">
+        <div class="itc-layout">
+          <figure class="itc-spider" data-labels="SM,NV,IP,HR" data-values="42,20,2,8" data-max="100" aria-label="Спайдер-диаграмма индекса технологичности">
+            <figcaption>SM — научный моментум, NV — новизна, IP — импакт, HR — готовность команд.</figcaption>
+          </figure>
+          <div class="itc-cards">
+            <div class="card"><h4>SM — 42</h4><p>Научный моментум замедляется: публикации фокусируются на оптимизации latency, observability и безопасности.</p></div>
+            <div class="card"><h4>NV — 20</h4><p>Новизна ограничена: основной фокус на управляемых сервисах, BYOC и снижении стоимости владения.</p></div>
+            <div class="card"><h4>IP — 2</h4><p>Импакт пока нишевый: требуется больше доказанных кейсов в высокорегулируемых индустриях.</p></div>
+            <div class="card"><h4>HR — 8</h4><p>Высокие барьеры: дефицит экспертов по stateful streams, exactly-once и платформенной надёжности.</p></div>
+          </div>
         </div>
       </div>
     </section>

--- a/streaming/index.html
+++ b/streaming/index.html
@@ -42,6 +42,8 @@
       background: linear-gradient(90deg, var(--blue-2), var(--blue-1)) no-repeat left bottom / 56px 4px;
     }
     section{ background:var(--card); border:1px solid var(--line); border-radius: var(--radius); padding: 20px; box-shadow: var(--shadow); }
+    section.itc{ background:none; border:none; box-shadow:none; padding:0; }
+    .itc-panel{ background:var(--card); border:1px solid var(--line); border-radius:var(--radius); padding:20px; box-shadow:var(--shadow); }
     .grid-2{ display:grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap:16px; }
     .grid-3{ display:grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap:16px; }
 
@@ -125,6 +127,7 @@
       .stats{ grid-template-columns:1fr; }
       header.hero{ padding:20px 18px; }
       section{ padding:16px; }
+      .itc-panel{ padding:16px; }
     }
     @media (max-width: 520px){
       .tag{ font-size:12px; }
@@ -155,17 +158,19 @@
       </div>
     </header>
 
-    <h2>Индекс технологичности (ITC)</h2>
-    <section>
-      <div class="itc-layout">
-        <figure class="itc-spider" data-labels="SM,NV,IP,HR" data-values="42,20,2,8" data-max="100" aria-label="Спайдер-диаграмма индекса технологичности">
-          <figcaption>SM — научный моментум, NV — новизна, IP — импакт, HR — готовность команд.</figcaption>
-        </figure>
-        <div class="itc-cards">
-          <div class="card"><h4>SM — 42</h4><p>Научный моментум замедляется: рост публикаций стабилизировался, фокус на инженерной оптимизации и доступности.</p></div>
-          <div class="card"><h4>NV — 20</h4><p>Новизна ограничена: индустрия переходит к управляемым сервисам, BYOC и serverless-моделям с упором на эффективность.</p></div>
-          <div class="card"><h4>IP — 2</h4><p>Импакт нишевый: требуется накопление крупных отраслевых референсов и кейсов в высокорискованных доменах.</p></div>
-          <div class="card"><h4>HR — 8</h4><p>Высокие барьеры входа: дефицит компетенций по stateful streams, exactly-once и операционному управлению кластером.</p></div>
+    <section class="itc">
+      <h2>Индекс технологичности (ITC)</h2>
+      <div class="itc-panel">
+        <div class="itc-layout">
+          <figure class="itc-spider" data-labels="SM,NV,IP,HR" data-values="42,20,2,8" data-max="100" aria-label="Спайдер-диаграмма индекса технологичности">
+            <figcaption>SM — научный моментум, NV — новизна, IP — импакт, HR — готовность команд.</figcaption>
+          </figure>
+          <div class="itc-cards">
+            <div class="card"><h4>SM — 42</h4><p>Научный моментум замедляется: рост публикаций стабилизировался, фокус на инженерной оптимизации и доступности.</p></div>
+            <div class="card"><h4>NV — 20</h4><p>Новизна ограничена: индустрия переходит к управляемым сервисам, BYOC и serverless-моделям с упором на эффективность.</p></div>
+            <div class="card"><h4>IP — 2</h4><p>Импакт нишевый: требуется накопление крупных отраслевых референсов и кейсов в высокорискованных доменах.</p></div>
+            <div class="card"><h4>HR — 8</h4><p>Высокие барьеры входа: дефицит компетенций по stateful streams, exactly-once и операционному управлению кластером.</p></div>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- restructure the ITC section markup across technology pages so the heading and spider chart live in a single container, preventing blank pages in PDFs
- update the print stylesheet to recognise the new ITC wrapper and keep the block together during printing
- adjust responsive padding so the refreshed ITC panel keeps its spacing on small screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fc916136a48333bdcb461a3abb923f