### PR TITLE
Add White Space visualization to main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,12 +99,19 @@
 
     /* Radar */
     .radar-wrap{ position:relative; border:1px solid var(--border); border-radius:var(--radius); padding:22px 22px 30px; background: var(--card); box-shadow: var(--shadow); }
-    .radar-toolbar{ display:flex; justify-content:flex-end; margin-bottom:16px; }
+    .radar-toolbar{ display:flex; justify-content:space-between; align-items:center; gap:16px; margin-bottom:16px; flex-wrap:wrap; }
+    .view-toggle{ display:inline-flex; align-items:center; gap:6px; padding:4px; border-radius:12px; background:var(--card-alt); border:1px solid var(--border); box-shadow:none; }
+    .view-toggle__btn{ border:0; background:transparent; padding:8px 16px; border-radius:10px; font-weight:600; font-size:14px; color:var(--muted); cursor:pointer; transition:background .2s ease, color .2s ease, box-shadow .2s ease, transform .2s ease; }
+    .view-toggle__btn:hover{ color:var(--text); }
+    .view-toggle__btn:focus-visible{ outline:3px solid rgba(37,99,235,.35); outline-offset:2px; }
+    .view-toggle__btn.is-active{ background:var(--accent); color:#fff; box-shadow:0 12px 28px rgba(37,99,235,.18); transform:translateY(-1px); }
     .radar-dashboard-link{ display:inline-flex; align-items:center; gap:8px; padding:10px 18px; border-radius:12px; background:var(--accent); color:#fff; font-weight:600; text-decoration:none; border:1px solid var(--accent); box-shadow:none; transition:background .2s ease, transform .2s ease; }
     .radar-dashboard-link:hover{ background:var(--accent-strong); transform:translateY(-1px); }
     .radar-dashboard-link:focus-visible{ outline:3px solid rgba(37,99,235,.35); outline-offset:3px; }
     .radar{ position:relative; width:100%; max-width:100%; height: clamp(440px, 58vw, 620px); margin:auto; background:
       radial-gradient(circle at center, rgba(37,99,235,.05) 0 1px, transparent 1px) 0 0/22px 22px; border-radius:18px; overflow:hidden; }
+    .whitespace{ position:relative; width:100%; max-width:100%; height: clamp(460px, 60vw, 640px); margin:auto; border-radius:18px; overflow:hidden; border:1px solid rgba(37,99,235,.14); background:linear-gradient(135deg, rgba(37,99,235,.08), rgba(37,99,235,.02)); box-shadow: inset 0 1px 0 rgba(255,255,255,.6); }
+    .whitespace svg{ position:absolute; inset:0; width:100%; height:100%; display:block; }
     .radar-empty{
       position:absolute;
       inset:16px;
@@ -120,6 +127,18 @@
       padding:18px;
       pointer-events:none;
     }
+    .whitespace-about{ margin:0 0 18px; padding:20px 22px; border-radius:16px; border:1px solid rgba(37,99,235,.12); background:linear-gradient(120deg, rgba(37,99,235,.1), rgba(255,255,255,.95)); box-shadow:0 20px 36px rgba(15,23,42,.08); }
+    .whitespace-about h3{ margin:0 0 10px; font-size:18px; font-weight:700; color:var(--text); }
+    .whitespace-about p{ margin:0 0 12px; color:var(--muted); }
+    .whitespace-about ul{ margin:0; padding:0; list-style:none; display:grid; gap:8px; }
+    .whitespace-about li{ position:relative; padding-left:18px; color:var(--muted); font-size:14px; line-height:1.5; }
+    .whitespace-about li::before{ content:""; position:absolute; left:0; top:8px; width:8px; height:8px; border-radius:50%; background:var(--accent); box-shadow:0 0 0 3px rgba(37,99,235,.18); }
+    .whitespace-grid-line{ stroke:rgba(148,163,184,.28); stroke-width:1; }
+    .whitespace-axis-line{ stroke:rgba(15,23,42,.38); stroke-width:1.3; }
+    .whitespace-axis-tick{ fill:var(--muted); font-size:11px; font-weight:500; }
+    .whitespace-axis-label{ fill:var(--muted); font-size:12px; font-weight:600; letter-spacing:.3px; text-transform:uppercase; }
+    .whitespace-guideline{ stroke:rgba(37,99,235,.45); stroke-width:1.2; stroke-dasharray:6 6; }
+    .whitespace-callout{ fill:var(--text); font-size:13px; font-weight:600; }
     .radar svg{ position:absolute; inset:0; width:100%; height:100%; }
     .ring-label{ display:block; font-size:12px; fill:var(--muted); font-weight:600; }
     .axis-line{ stroke:rgba(37,99,235,.18); stroke-width:1; stroke-dasharray:4 4; }
@@ -149,6 +168,8 @@
     .radar-tooltip.is-visible{ opacity:1; }
     .radar-tooltip strong{ display:block; font-size:14px; margin-bottom:6px; color:var(--accent); }
     .radar-tooltip p{ margin:0 0 8px; font-size:12px; color:var(--muted); }
+    .radar-tooltip .tooltip-summary + .tooltip-summary{ margin-top:6px; }
+    .radar-tooltip .tooltip-caption{ display:block; font-size:10px; font-weight:600; letter-spacing:.4px; text-transform:uppercase; color:var(--muted); margin-bottom:2px; }
     .radar-tooltip .tooltip-tags{ display:flex; flex-wrap:wrap; gap:6px; margin:0; }
     .radar-tooltip .tooltip-tag{ display:inline-flex; align-items:center; padding:4px 8px; border-radius:999px; background:var(--accent-soft); color:var(--accent); font-size:11px; font-weight:600; letter-spacing:.2px; }
     .radar-tooltip .tooltip-kpis{ margin:10px 0 0; padding:0; list-style:none; display:flex; flex-direction:column; gap:6px; }
@@ -185,8 +206,11 @@
     @media (max-width: 640px){
       .board{ grid-template-columns: 1fr; }
       .radar{ height: clamp(360px, 90vw, 520px); }
+      .whitespace{ height: clamp(360px, 90vw, 540px); }
       .radar-wrap{ padding:14px; }
       .radar-toolbar{ margin-bottom:12px; }
+      .view-toggle{ width:100%; justify-content:space-between; }
+      .view-toggle__btn{ flex:1; text-align:center; }
       .radar-dashboard-link{ width:100%; justify-content:center; }
     }
     @media (max-width: 480px){
@@ -194,6 +218,7 @@
       .search{ flex-direction:column; }
       .search input{ padding-left:38px; }
       .radar{ height: clamp(320px, 110vw, 440px); }
+      .whitespace{ height: clamp(320px, 110vw, 460px); }
     }
 
     @media print{
@@ -210,6 +235,9 @@
     .tile .kpi-list{ margin:8px 0 0; padding:0; list-style:none; display:flex; flex-direction:column; gap:6px; }
     .tile .kpi-item{ display:flex; gap:8px; align-items:flex-start; font-size:12px; color:var(--muted); }
     .tile .kpi-value{ color:var(--accent-strong); font-weight:700; }
+    .tile-story{ margin:10px 0 0; font-size:13px; color:var(--muted); line-height:1.45; }
+    .tile[data-disabled='true']{ cursor:default; }
+    .tile[data-disabled='true']:hover{ transform:none; box-shadow: 0 14px 26px rgba(15,23,42,.04); border-color:var(--border); }
 
     footer{ color:var(--muted); font-size:12px; margin-top: 36px; text-align:center; }
   </style>
@@ -236,12 +264,29 @@
       <button class="clear" id="clearBtn" type="button">Очистить</button>
     </div>
 
-    <section class="radar-wrap" aria-label="Цифровой радар технологий">
+    <section class="radar-wrap" aria-label="Цифровой радар технологий и карта возможностей">
       <div class="radar-toolbar">
+        <div class="view-toggle" role="tablist" aria-label="Переключатель визуализаций">
+          <button type="button" class="view-toggle__btn is-active" data-view="radar" role="tab" aria-selected="true" aria-controls="radar" id="viewRadar">Радар</button>
+          <button type="button" class="view-toggle__btn" data-view="whitespace" role="tab" aria-selected="false" aria-controls="whiteSpace" id="viewWhiteSpace">White Space</button>
+        </div>
         <a class="radar-dashboard-link" href="https://datalens.yandex/unblwg4lldxmf" target="_blank" rel="noopener">Перейти в дашборд</a>
       </div>
-      <div id="radar" class="radar"></div>
+      <div id="whiteSpaceAbout" class="whitespace-about" hidden>
+        <h3>White Space карта</h3>
+        <p>Диаграмма помогает увидеть незаполненные ниши: по оси X — моментум и скорость распространения, по оси Y — новизна. Размер пузыря отражает ожидаемый импакт, а цвет показывает зрелость и доступность экспертизы на рынке.</p>
+        <p>Используйте карту, чтобы подготовиться к стратегическим дискуссиям и быстрее выбирать направления развития.</p>
+        <ul>
+          <li>Фокусировать внимание на технологиях с сочетанием высокого импакта и управляемой сложности внедрения.</li>
+          <li>Синхронизировать продуктовые, исследовательские и коммерческие команды вокруг общих приоритетов.</li>
+          <li>Проверять инвестиционные гипотезы через призму спроса, новизны и готовности талантов.</li>
+        </ul>
+        <p><strong>Зона White Space</strong> — верхний правый сегмент диаграммы, где новизна и моментум растут, а конкуренция пока низкая.</p>
+      </div>
+      <div id="radar" class="radar" role="tabpanel" aria-labelledby="viewRadar"></div>
+      <div id="whiteSpace" class="whitespace" role="tabpanel" aria-labelledby="viewWhiteSpace" hidden></div>
       <div id="radarEmpty" class="radar-empty" hidden role="status" aria-live="polite">Нет технологий для отображения. Измените поисковый запрос.</div>
+      <div id="whiteSpaceEmpty" class="radar-empty" hidden role="status" aria-live="polite">Нет технологий для отображения на карте White Space. Измените поисковый запрос.</div>
     </section>
 
     <h2>Доска технологий</h2>
@@ -453,6 +498,195 @@ const technologies = (activeAccountConfig?.technologies || []).map((item, index)
   return { ...item, metrics, kpis, link, order: index + 1 };
 });
 
+const formatDecimal = (value, digits = 2)=>{
+  const num = Number(value);
+  if(Number.isFinite(num)){
+    const out = num.toFixed(digits);
+    if(out === '-0.00'){
+      return '0.00';
+    }
+    return out.replace('-', '−');
+  }
+  return (value ?? '').toString();
+};
+
+const whiteSpaceRaw = [
+  {
+    id:'ws-1',
+    slug:'ekg',
+    name:'Платформы корпоративных графов знаний',
+    summary:'широкая диффузия, низкая новизна; стандарты ISO GQL 2024, W3C SPARQL 1.2; рост 15–34% CAGR.',
+    story:'семантический слой для поиска/аналитики/GenAI.',
+    what:'RDF/OWL/SPARQL и property-graph/GQL для моделирования сущностей.',
+    techScore:'~0.21',
+    novelty:2.380952,
+    momentum:-2.178305,
+    impact:1.423047,
+    impactScore:66,
+    maturity:0.21,
+    metrics:['RDF/OWL/SPARQL','Property-graph / GQL','Семантическое моделирование']
+  },
+  {
+    id:'ws-2',
+    slug:'semantic-pipelines',
+    name:'Платформы корпоративных семантических графов знаний',
+    summary:'высокая новизна, умеренная диффузия; рынок растёт двузначными темпами.',
+    story:'интероперабельные запросы, reasoning, lineage, discovery для GenAI.',
+    what:'онтологии + RDF/OWL/SHACL/SPARQL, гибрид с GQL/SQL; GraphRAG/семантический слой для BI/MDM.',
+    techScore:'~0.50',
+    novelty:0.909091,
+    momentum:-1.36264,
+    impact:1.044084,
+    impactScore:49,
+    maturity:0.11,
+    metrics:['RDF/OWL/SHACL','Гибрид GQL + SQL','GraphRAG & Semantic BI']
+  },
+  {
+    id:'ws-3',
+    slug:null,
+    name:'Платформы интероперабельности данных здравоохранения на основе стандартов',
+    summary:'зрелые в США/UK; рост ~14% CAGR; общий моментум снижается.',
+    story:'ниже стоимость интеграций, быстрее аналитика, лучше качество ухода.',
+    what:'FHIR/OMOP-интероперабельность.',
+    techScore:'~0.35',
+    novelty:0.909091,
+    momentum:-4.735161,
+    impact:0.518175,
+    impactScore:24,
+    maturity:0.11,
+    metrics:['FHIR','OMOP','Healthcare interoperability']
+  },
+  {
+    id:'ws-4',
+    slug:'streaming-rt',
+    name:'Платформы распределённой потоковой передачи событий и обработки потоков в реальном времени',
+    summary:'зрелая и широко внедрённая, моментум нейтрал/слегка отрицательный; фокус на эффективности и AI-интеграции.',
+    story:'миллисекундные ETL, realtime-аналитика и приложения.',
+    what:'журналы событий и pub/sub (Kafka/Pulsar) + stateful-движки (Flink/Kafka Streams).',
+    techScore:'~0.50',
+    novelty:1.875,
+    momentum:-1.089836,
+    impact:0.518175,
+    impactScore:24,
+    maturity:0.16,
+    metrics:['Kafka / Pulsar','Flink / Kafka Streams','Realtime ETL']
+  },
+  {
+    id:'ws-5',
+    slug:'semantic-pipelines',
+    name:'Семантические конвейеры интеграции и обработки данных',
+    summary:'высокая новизна, ограниченная диффузия; идёт стандартизация и индустриализация.',
+    story:'находимость, совместимость и переиспользуемость данных.',
+    what:'онтологии+метаданные, entity linking, валидация (FAIR, DCAT/PROV), от ingestion до сервинга.',
+    techScore:'~0.46',
+    novelty:0.833333,
+    momentum:-3.380517,
+    impact:0.881671,
+    impactScore:41,
+    maturity:0.12,
+    metrics:['Онтологии + метаданные','Entity Linking','FAIR / DCAT / PROV']
+  },
+  {
+    id:'ws-6',
+    slug:'disaggregated-storage',
+    name:'Дезагрегированные распределённые архитектуры хранения для корпоративных платформ данных',
+    summary:'де-факто стандарт в облаках; on-prem активно догоняет; рост умеренный.',
+    story:'эластичность, ниже TCO, отказоустойчивость, изоляция нагрузок.',
+    what:'разделение compute/storage, объектные и KV-движки, EC, tiering, ZNS-SSD, DPU/SmartNIC, HTAP.',
+    techScore:'~0.47',
+    novelty:2.0,
+    momentum:-3.286671,
+    impact:0.788863,
+    impactScore:37,
+    maturity:0.15,
+    metrics:['Compute / Storage decoupling','Object & KV engines','ZNS-SSD · SmartNIC · HTAP']
+  },
+  {
+    id:'ws-7',
+    slug:'blockchain-governance',
+    name:'Корпоративные системы управления данными и обеспечения целостности на основе блокчейна',
+    summary:'пилоты и узкие прод-кейсы, моментум отрицательный; масштабирование 2–5 лет.',
+    story:'доверие и неизменяемость в межорганизационных потоках данных.',
+    what:'DLT для lineage/доступа/consent/аудита со смарт-контрактами.',
+    techScore:'~0.49',
+    novelty:3.0,
+    momentum:-1.631137,
+    impact:0.510441,
+    impactScore:24,
+    maturity:0.09,
+    metrics:['DLT lineage','Access & consent','Смарт-контракты']
+  },
+  {
+    id:'ws-8',
+    slug:null,
+    name:'Базы данных векторных эмбеддингов и системы индексации сходств',
+    summary:'самый высокий импакт, моментум остыл; массовая интеграция в СУБД, пилоты 0–12 мес.',
+    story:'семантический поиск, рекомендации, RAG.',
+    what:'ANN-индексы (HNSW/IVF/PQ/DiskANN), гибрид запросов, GPU (FAISS/cuVS).',
+    techScore:'~0.35',
+    novelty:1.666667,
+    momentum:-2.800804,
+    impact:2.142305,
+    impactScore:100,
+    maturity:0.12,
+    metrics:['ANN: HNSW / IVF / PQ','Hybrid Search','GPU: FAISS / cuVS']
+  },
+  {
+    id:'ws-9',
+    slug:null,
+    name:'Системы оптимизации SQL-запросов с применением машинного обучения',
+    summary:'высокий импакт, моментум остыл, диффузия низкая; горизонт 1–3 года.',
+    story:'−30–70% время запросов, меньше регрессий и ручного тюнинга.',
+    what:'ML для кардинальностей/стоимости/ранжирования планов, авто-тюнинг; Azure SQL/Oracle и исследовательские Bao/LEON и др.',
+    techScore:'~0.50',
+    novelty:0.833333,
+    momentum:-2.173204,
+    impact:1.910286,
+    impactScore:89,
+    maturity:0.1,
+    metrics:['ML query planning','Auto-tuning','Azure SQL · Oracle · Bao']
+  },
+  {
+    id:'ws-10',
+    slug:null,
+    name:'Ориентированные на аналитику технологии сжатия данных для колоночных и крупномасштабных систем хранения',
+    summary:'высокая новизна и положительный моментум, низкая диффузия — лучшее «white space» на 12–24 мес.',
+    story:'резкое снижение объёма и I/O, ускорение ETL/SQL на CPU/GPU.',
+    what:'лёгкие/адаптивные/нейро-, мультиколоночные схемы сжатия, встроенные в Parquet/ORC/движки.',
+    techScore:'~0.57',
+    novelty:3.333333,
+    momentum:2.96812,
+    impact:0.262954,
+    impactScore:12,
+    maturity:0.06,
+    metrics:['Адаптивное сжатие','Нейро-кодеки','Parquet / ORC acceleration']
+  }
+];
+
+const whiteSpaceItems = whiteSpaceRaw.map((item, index)=>{
+  const metrics = Array.isArray(item.metrics) ? item.metrics.filter(Boolean) : [];
+  const link = item.slug ? makeLink(item.slug) : '#';
+  const kpis = [
+    { value: (item.techScore || '').toString(), label: 'TechScore' },
+    { value: formatDecimal(item.novelty), label: 'Новизна' },
+    { value: formatDecimal(item.momentum), label: 'Моментум' },
+    { value: `${item.impactScore}%`, label: 'Impact (норм.)' }
+  ];
+  return { ...item, metrics, kpis, link, order: index + 1 };
+});
+
+const whiteSpaceMaxImpact = Math.max(1, ...whiteSpaceItems.map((item)=> Number(item.impact) || 0));
+const whiteSpaceMaturityRange = whiteSpaceItems.reduce((acc, item)=>{
+  const value = Number(item.maturity);
+  if(Number.isFinite(value)){
+    if(value < acc.min){ acc.min = value; }
+    if(value > acc.max){ acc.max = value; }
+  }
+  return acc;
+}, { min: Infinity, max: -Infinity });
+if(!Number.isFinite(whiteSpaceMaturityRange.min)){ whiteSpaceMaturityRange.min = 0; whiteSpaceMaturityRange.max = 1; }
+const whiteSpaceBenchmark = { momentum: -2.1757546507614007, novelty: 1.7708333333333335 };
+
 const brandEl = document.getElementById('projectBrand');
 const baseBrand = 'Технологический радар';
 if(brandEl){
@@ -480,6 +714,11 @@ const radarEmptyEl = document.getElementById('radarEmpty');
 const radarWrapEl = radarEl ? radarEl.parentElement : null;
 const boardEl = document.getElementById('board');
 const boardEmptyEl = document.getElementById('boardEmpty');
+const whiteSpaceEl = document.getElementById('whiteSpace');
+const whiteSpaceEmptyEl = document.getElementById('whiteSpaceEmpty');
+const whiteSpaceAboutEl = document.getElementById('whiteSpaceAbout');
+const viewToggleButtons = Array.from(document.querySelectorAll('.view-toggle__btn'));
+const dashboardLinkEl = document.querySelector('.radar-dashboard-link');
 const rings = [
   {id:'observe',   label:'Наблюдение', r:140, color:'#bae6fd'},
   {id:'pilot',     label:'Пилоты',     r:220, color:'#7dd3fc'},
@@ -488,8 +727,13 @@ const rings = [
 ];
 const ringLabelsById = rings.reduce((acc, ring)=>{ acc[ring.id] = ring.label; return acc; }, {});
 let lastRadarData = technologies;
+let lastWhiteSpaceData = whiteSpaceItems;
 let radarTooltipEl = null;
 let radarTooltipTimer = null;
+const baseByView = { radar: technologies, whitespace: whiteSpaceItems };
+const filteredByView = { radar: technologies, whitespace: whiteSpaceItems };
+let activeView = 'radar';
+let lastSearchTerms = [];
 
 if(radarWrapEl){
   radarTooltipEl = radarWrapEl.querySelector('.radar-tooltip');
@@ -500,6 +744,16 @@ if(radarWrapEl){
     radarTooltipEl.hidden = true;
     radarWrapEl.appendChild(radarTooltipEl);
   }
+}
+
+function hideTooltip(){
+  if(!radarTooltipEl){ return; }
+  if(radarTooltipTimer !== null){
+    cancelAnimationFrame(radarTooltipTimer);
+    radarTooltipTimer = null;
+  }
+  radarTooltipEl.classList.remove('is-visible');
+  radarTooltipEl.hidden = true;
 }
 
 function polarToXY(cx, cy, r, angleDeg){
@@ -513,11 +767,7 @@ function renderRadar(data){
   lastRadarData = items;
   const w = radarEl.clientWidth || radarEl.offsetWidth || 800;
   const h = radarEl.clientHeight || radarEl.offsetHeight || 520;
-  if(radarTooltipEl){
-    if(radarTooltipTimer !== null){ cancelAnimationFrame(radarTooltipTimer); radarTooltipTimer = null; }
-    radarTooltipEl.classList.remove('is-visible');
-    radarTooltipEl.hidden = true;
-  }
+  hideTooltip();
   const cx = w/2, cy = h/2;
   const maxR = Math.min(w,h)/2 - 36;
   const scale = maxR / rings[rings.length-1].r;
@@ -560,12 +810,7 @@ function renderRadar(data){
   if(!items.length){
     radarEl.innerHTML = '';
     radarEl.appendChild(svg);
-    if(radarEmptyEl){ radarEmptyEl.hidden = false; }
-    if(radarTooltipEl){
-      if(radarTooltipTimer !== null){ cancelAnimationFrame(radarTooltipTimer); radarTooltipTimer = null; }
-      radarTooltipEl.classList.remove('is-visible');
-      radarTooltipEl.hidden = true;
-    }
+    hideTooltip();
     return;
   }
 
@@ -641,12 +886,6 @@ function renderRadar(data){
         radarTooltipTimer = null;
       });
     };
-    const hideTooltip = ()=>{
-      if(!radarTooltipEl){ return; }
-      if(radarTooltipTimer !== null){ cancelAnimationFrame(radarTooltipTimer); radarTooltipTimer = null; }
-      radarTooltipEl.classList.remove('is-visible');
-      radarTooltipEl.hidden = true;
-    };
     g.addEventListener('mouseenter', showTooltip);
     g.addEventListener('focus', showTooltip);
     g.addEventListener('mouseleave', hideTooltip);
@@ -660,21 +899,458 @@ function renderRadar(data){
 
   radarEl.innerHTML = '';
   radarEl.appendChild(svg);
-  if(radarEmptyEl){ radarEmptyEl.hidden = true; }
-  if(radarTooltipEl){
-    if(radarTooltipTimer !== null){ cancelAnimationFrame(radarTooltipTimer); radarTooltipTimer = null; }
-    radarTooltipEl.classList.remove('is-visible');
-    radarTooltipEl.hidden = true;
+  hideTooltip();
+}
+
+const svgNS = 'http://www.w3.org/2000/svg';
+
+const hexToRgb = (hex)=>{
+  const cleaned = (hex || '').toString().replace('#','').trim();
+  if(!cleaned){ return { r:37, g:99, b:235 }; }
+  const normalized = cleaned.length === 3
+    ? cleaned.split('').map((ch)=> ch + ch).join('')
+    : cleaned.padEnd(6,'0').slice(0,6);
+  const num = Number.parseInt(normalized, 16);
+  if(Number.isNaN(num)){ return { r:37, g:99, b:235 }; }
+  return { r:(num >> 16) & 255, g:(num >> 8) & 255, b:num & 255 };
+};
+
+const mixColors = (from, to, t)=>{
+  const start = hexToRgb(from);
+  const end = hexToRgb(to);
+  const ratio = Math.min(Math.max(t, 0), 1);
+  const r = Math.round(start.r + (end.r - start.r) * ratio);
+  const g = Math.round(start.g + (end.g - start.g) * ratio);
+  const b = Math.round(start.b + (end.b - start.b) * ratio);
+  return `rgb(${r}, ${g}, ${b})`;
+};
+
+const colorFromMaturity = (value)=>{
+  const min = whiteSpaceMaturityRange.min;
+  const max = whiteSpaceMaturityRange.max;
+  if(!Number.isFinite(value)){ value = min; }
+  if(!Number.isFinite(min) || !Number.isFinite(max) || max <= min){
+    return 'rgb(37, 99, 235)';
   }
+  const ratio = Math.min(Math.max((value - min) / (max - min), 0), 1);
+  return mixColors('#60a5fa', '#1d4ed8', ratio);
+};
+
+function renderWhiteSpace(data){
+  if(!whiteSpaceEl){ return; }
+  const items = Array.isArray(data) ? data : [];
+  lastWhiteSpaceData = items;
+  const width = whiteSpaceEl.clientWidth || whiteSpaceEl.offsetWidth || 800;
+  const height = whiteSpaceEl.clientHeight || whiteSpaceEl.offsetHeight || 560;
+  whiteSpaceEl.innerHTML = '';
+  hideTooltip();
+
+  const padding = { top: 42, right: 44, bottom: 74, left: 86 };
+  const innerWidth = Math.max(0, width - padding.left - padding.right);
+  const innerHeight = Math.max(0, height - padding.top - padding.bottom);
+
+  const xValues = items.map((item)=> Number(item.momentum)).filter(Number.isFinite);
+  const yValues = items.map((item)=> Number(item.novelty)).filter(Number.isFinite);
+  let xMin = xValues.length ? Math.min(...xValues) : -4;
+  let xMax = xValues.length ? Math.max(...xValues) : 3;
+  let yMin = yValues.length ? Math.min(...yValues) : 0;
+  let yMax = yValues.length ? Math.max(...yValues) : 3;
+  const xMargin = xValues.length ? Math.max(0.6, (xMax - xMin) * 0.12) : 1;
+  const yMargin = yValues.length ? Math.max(0.4, (yMax - yMin) * 0.12) : 0.6;
+  xMin -= xMargin;
+  xMax += xMargin;
+  yMin = Math.max(0, yMin - yMargin);
+  yMax += yMargin;
+  const xRange = xMax - xMin || 1;
+  const yRange = yMax - yMin || 1;
+  const scaleX = (value)=> padding.left + ((value - xMin) / xRange) * innerWidth;
+  const scaleY = (value)=> padding.top + innerHeight - ((value - yMin) / yRange) * innerHeight;
+
+  const svg = document.createElementNS(svgNS, 'svg');
+  svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+
+  const defs = document.createElementNS(svgNS, 'defs');
+  const gradientId = `wsGrad-${Math.random().toString(36).slice(2,8)}`;
+  const gradient = document.createElementNS(svgNS, 'linearGradient');
+  gradient.setAttribute('id', gradientId);
+  gradient.setAttribute('x1','0%');
+  gradient.setAttribute('y1','0%');
+  gradient.setAttribute('x2','100%');
+  gradient.setAttribute('y2','100%');
+  const stopStart = document.createElementNS(svgNS,'stop');
+  stopStart.setAttribute('offset','0%');
+  stopStart.setAttribute('stop-color','rgba(96,165,250,0.24)');
+  gradient.appendChild(stopStart);
+  const stopEnd = document.createElementNS(svgNS,'stop');
+  stopEnd.setAttribute('offset','100%');
+  stopEnd.setAttribute('stop-color','rgba(37,99,235,0.05)');
+  gradient.appendChild(stopEnd);
+  defs.appendChild(gradient);
+  svg.appendChild(defs);
+
+  const background = document.createElementNS(svgNS,'rect');
+  background.setAttribute('x', 0);
+  background.setAttribute('y', 0);
+  background.setAttribute('width', width);
+  background.setAttribute('height', height);
+  background.setAttribute('fill', `url(#${gradientId})`);
+  svg.appendChild(background);
+
+  let benchmarkRect = null;
+  let benchmarkX = null;
+  let benchmarkY = null;
+  if(Number.isFinite(whiteSpaceBenchmark.momentum) && Number.isFinite(whiteSpaceBenchmark.novelty)){
+    benchmarkX = Math.min(width - padding.right, Math.max(padding.left, scaleX(whiteSpaceBenchmark.momentum)));
+    benchmarkY = Math.max(padding.top, Math.min(height - padding.bottom, scaleY(whiteSpaceBenchmark.novelty)));
+    const highlight = document.createElementNS(svgNS,'rect');
+    highlight.setAttribute('x', benchmarkX);
+    highlight.setAttribute('y', padding.top);
+    highlight.setAttribute('width', Math.max(0, (width - padding.right) - benchmarkX));
+    highlight.setAttribute('height', Math.max(0, benchmarkY - padding.top));
+    highlight.setAttribute('fill','rgba(37,99,235,0.08)');
+    highlight.setAttribute('stroke','rgba(37,99,235,0.16)');
+    highlight.setAttribute('stroke-dasharray','6 6');
+    highlight.setAttribute('rx', 14);
+    svg.appendChild(highlight);
+    benchmarkRect = highlight;
+  }
+
+  const gridGroup = document.createElementNS(svgNS,'g');
+  gridGroup.setAttribute('fill','none');
+  const xTickStart = Math.ceil(xMin);
+  const xTickEnd = Math.floor(xMax);
+  for(let tick = xTickStart; tick <= xTickEnd; tick++){
+    const xPos = scaleX(tick);
+    const line = document.createElementNS(svgNS,'line');
+    line.setAttribute('x1', xPos);
+    line.setAttribute('y1', padding.top);
+    line.setAttribute('x2', xPos);
+    line.setAttribute('y2', height - padding.bottom);
+    line.setAttribute('class','whitespace-grid-line');
+    gridGroup.appendChild(line);
+    const label = document.createElementNS(svgNS,'text');
+    label.setAttribute('class','whitespace-axis-tick');
+    label.setAttribute('x', xPos);
+    label.setAttribute('y', height - padding.bottom + 28);
+    label.setAttribute('text-anchor','middle');
+    label.textContent = tick.toString().replace('-', '−');
+    gridGroup.appendChild(label);
+  }
+  const yTickStart = Math.ceil(yMin);
+  const yTickEnd = Math.floor(yMax);
+  for(let tick = yTickStart; tick <= yTickEnd; tick++){
+    const yPos = scaleY(tick);
+    const line = document.createElementNS(svgNS,'line');
+    line.setAttribute('x1', padding.left);
+    line.setAttribute('y1', yPos);
+    line.setAttribute('x2', width - padding.right);
+    line.setAttribute('y2', yPos);
+    line.setAttribute('class','whitespace-grid-line');
+    gridGroup.appendChild(line);
+    const label = document.createElementNS(svgNS,'text');
+    label.setAttribute('class','whitespace-axis-tick');
+    label.setAttribute('x', padding.left - 18);
+    label.setAttribute('y', yPos + 4);
+    label.setAttribute('text-anchor','end');
+    label.textContent = tick.toString().replace('-', '−');
+    gridGroup.appendChild(label);
+  }
+  svg.appendChild(gridGroup);
+
+  if(benchmarkRect){
+    const vGuide = document.createElementNS(svgNS,'line');
+    vGuide.setAttribute('x1', benchmarkX);
+    vGuide.setAttribute('y1', padding.top);
+    vGuide.setAttribute('x2', benchmarkX);
+    vGuide.setAttribute('y2', height - padding.bottom);
+    vGuide.setAttribute('class','whitespace-guideline');
+    svg.appendChild(vGuide);
+    const hGuide = document.createElementNS(svgNS,'line');
+    hGuide.setAttribute('x1', padding.left);
+    hGuide.setAttribute('y1', benchmarkY);
+    hGuide.setAttribute('x2', width - padding.right);
+    hGuide.setAttribute('y2', benchmarkY);
+    hGuide.setAttribute('class','whitespace-guideline');
+    svg.appendChild(hGuide);
+
+    const calloutGroup = document.createElementNS(svgNS,'g');
+    let calloutX = Math.min(width - padding.right - 20, benchmarkX + 20);
+    let calloutY = benchmarkY - 24;
+    if(calloutY < padding.top + 24){
+      calloutY = Math.min(height - padding.bottom - 24, benchmarkY + 32);
+    }
+    const calloutText = document.createElementNS(svgNS,'text');
+    calloutText.setAttribute('class','whitespace-callout');
+    calloutText.setAttribute('x', calloutX);
+    calloutText.setAttribute('y', calloutY);
+    calloutText.textContent = 'Зона White Space';
+    calloutGroup.appendChild(calloutText);
+    svg.appendChild(calloutGroup);
+    const bbox = calloutText.getBBox();
+    const padX = 10;
+    const padY = 6;
+    const calloutRect = document.createElementNS(svgNS,'rect');
+    calloutRect.setAttribute('x', bbox.x - padX);
+    calloutRect.setAttribute('y', bbox.y - padY);
+    calloutRect.setAttribute('width', bbox.width + padX * 2);
+    calloutRect.setAttribute('height', bbox.height + padY * 2);
+    calloutRect.setAttribute('rx', 8);
+    calloutRect.setAttribute('fill','rgba(37,99,235,0.18)');
+    calloutRect.setAttribute('stroke','rgba(37,99,235,0.35)');
+    calloutRect.setAttribute('stroke-width','1');
+    calloutGroup.insertBefore(calloutRect, calloutText);
+  }
+
+  const axisGroup = document.createElementNS(svgNS,'g');
+  const xAxisLine = document.createElementNS(svgNS,'line');
+  xAxisLine.setAttribute('x1', padding.left);
+  xAxisLine.setAttribute('y1', height - padding.bottom);
+  xAxisLine.setAttribute('x2', width - padding.right);
+  xAxisLine.setAttribute('y2', height - padding.bottom);
+  xAxisLine.setAttribute('class','whitespace-axis-line');
+  axisGroup.appendChild(xAxisLine);
+  const yAxisLine = document.createElementNS(svgNS,'line');
+  yAxisLine.setAttribute('x1', padding.left);
+  yAxisLine.setAttribute('y1', padding.top);
+  yAxisLine.setAttribute('x2', padding.left);
+  yAxisLine.setAttribute('y2', height - padding.bottom);
+  yAxisLine.setAttribute('class','whitespace-axis-line');
+  axisGroup.appendChild(yAxisLine);
+  svg.appendChild(axisGroup);
+
+  const xLabel = document.createElementNS(svgNS,'text');
+  xLabel.setAttribute('class','whitespace-axis-label');
+  xLabel.setAttribute('x', padding.left + innerWidth / 2);
+  xLabel.setAttribute('y', height - padding.bottom + 52);
+  xLabel.setAttribute('text-anchor','middle');
+  xLabel.textContent = 'Моментум';
+  svg.appendChild(xLabel);
+
+  const yLabel = document.createElementNS(svgNS,'text');
+  yLabel.setAttribute('class','whitespace-axis-label');
+  yLabel.setAttribute('transform', `rotate(-90 ${padding.left - 58} ${padding.top + innerHeight / 2})`);
+  yLabel.setAttribute('x', padding.left - 58);
+  yLabel.setAttribute('y', padding.top + innerHeight / 2);
+  yLabel.setAttribute('text-anchor','middle');
+  yLabel.textContent = 'Новизна';
+  svg.appendChild(yLabel);
+
+  const bubbleGroup = document.createElementNS(svgNS,'g');
+  svg.appendChild(bubbleGroup);
+
+  items.forEach((item, idx)=>{
+    const momentum = Number(item.momentum);
+    const novelty = Number(item.novelty);
+    if(!Number.isFinite(momentum) || !Number.isFinite(novelty)){ return; }
+    const x = scaleX(momentum);
+    const y = scaleY(novelty);
+    const impact = Number(item.impact);
+    const impactRatio = whiteSpaceMaxImpact ? Math.max(0, (impact || 0) / whiteSpaceMaxImpact) : 0;
+    const radius = 18 + Math.sqrt(impactRatio) * 26;
+    const maturity = Number(item.maturity);
+    const fillColor = colorFromMaturity(maturity);
+    const strokeColor = mixColors('#1d4ed8', '#0f172a', Math.min(1, Math.max(0, (Number.isFinite(maturity) ? (maturity - whiteSpaceMaturityRange.min) / ((whiteSpaceMaturityRange.max - whiteSpaceMaturityRange.min) || 1) : 0.5) + 0.1)));
+
+    const group = document.createElementNS(svgNS,'g');
+    group.setAttribute('class','dot');
+    group.setAttribute('data-id', item.id || `ws-${idx + 1}`);
+
+    const circle = document.createElementNS(svgNS,'circle');
+    circle.setAttribute('cx', x);
+    circle.setAttribute('cy', y);
+    circle.setAttribute('r', radius);
+    circle.setAttribute('fill', fillColor);
+    circle.setAttribute('stroke', strokeColor);
+    circle.setAttribute('stroke-width', '1.6');
+    circle.setAttribute('aria-hidden','true');
+    circle.style.filter = 'drop-shadow(0 12px 32px rgba(37,99,235,0.22))';
+    group.appendChild(circle);
+
+    const orderLabel = (item.order || idx + 1).toString().padStart(2,'0');
+    const label = document.createElementNS(svgNS,'text');
+    label.setAttribute('class','dot-label');
+    label.setAttribute('x', x);
+    label.setAttribute('y', y + 1);
+    label.textContent = orderLabel;
+    group.appendChild(label);
+
+    const go = ()=>{
+      if(item.link && item.link !== '#'){
+        window.location.href = item.link;
+      }
+    };
+
+    group.setAttribute('role','link');
+    group.setAttribute('tabindex','0');
+    group.addEventListener('click', (event)=>{
+      if(item.link && item.link !== '#'){
+        event.preventDefault();
+        go();
+      }
+    });
+    group.addEventListener('keydown', (event)=>{
+      if((event.key === 'Enter' || event.key === ' ') && item.link && item.link !== '#'){
+        event.preventDefault();
+        go();
+      }
+    });
+
+    const showTooltip = ()=>{
+      if(!radarTooltipEl || !radarWrapEl){ return; }
+      const summaryParts = [];
+      if(item.story){ summaryParts.push(`<p class="tooltip-summary"><span class="tooltip-caption">Зачем</span>${item.story}</p>`); }
+      if(item.what){ summaryParts.push(`<p class="tooltip-summary"><span class="tooltip-caption">Что</span>${item.what}</p>`); }
+      if(item.summary){ summaryParts.push(`<p class="tooltip-summary">${item.summary}</p>`); }
+      const summaryHtml = summaryParts.join('');
+      const tagsHtml = (item.metrics || []).slice(0,6).map((m)=>`<span class="tooltip-tag">${m}</span>`).join('');
+      const tagsBlock = tagsHtml ? `<div class="tooltip-tags">${tagsHtml}</div>` : '';
+      const kpiHtml = (item.kpis || []).slice(0,4)
+        .map((kpi)=>{
+          const value = (kpi.value || '').toString();
+          const labelText = (kpi.label || '').toString();
+          return `<li class="tooltip-kpi"><span class="kpi-value">${value}</span><span>${labelText}</span></li>`;
+        })
+        .join('');
+      const kpiBlock = kpiHtml ? `<ul class="tooltip-kpis">${kpiHtml}</ul>` : '';
+      radarTooltipEl.innerHTML = `<strong>${orderLabel}. ${item.name}</strong>${summaryHtml}${tagsBlock}${kpiBlock}`;
+      const wrapRect = radarWrapEl.getBoundingClientRect();
+      const svgRect = svg.getBoundingClientRect();
+      const scaleXFactor = svgRect.width / width;
+      const scaleYFactor = svgRect.height / height;
+      const left = svgRect.left - wrapRect.left + x * scaleXFactor;
+      const top = svgRect.top - wrapRect.top + y * scaleYFactor;
+      radarTooltipEl.style.left = `${left}px`;
+      radarTooltipEl.style.top = `${top}px`;
+      radarTooltipEl.hidden = false;
+      if(radarTooltipTimer !== null){ cancelAnimationFrame(radarTooltipTimer); }
+      radarTooltipTimer = requestAnimationFrame(()=>{
+        radarTooltipEl.classList.add('is-visible');
+        radarTooltipTimer = null;
+      });
+    };
+
+    group.addEventListener('mouseenter', showTooltip);
+    group.addEventListener('focus', showTooltip);
+    group.addEventListener('mouseleave', hideTooltip);
+    group.addEventListener('blur', hideTooltip);
+    group.addEventListener('touchstart', showTooltip, { passive: true });
+    group.addEventListener('touchend', hideTooltip);
+    group.addEventListener('touchcancel', hideTooltip);
+
+    bubbleGroup.appendChild(group);
+  });
+
+  whiteSpaceEl.appendChild(svg);
+}
+
+const normalizeText = (value)=> (value ?? '').toString().toLowerCase();
+
+function filterList(list, terms){
+  const items = Array.isArray(list) ? list : [];
+  if(!terms.length){ return items; }
+  const normalizedTerms = terms.map(normalizeText);
+  const makeBag = (t)=>{
+    const parts = [
+      t.name,
+      t.slug,
+      t.ring,
+      ringLabelsById[t.ring],
+      t.summary,
+      t.story,
+      t.what,
+      t.techScore,
+      Number.isFinite(Number(t.novelty)) ? formatDecimal(t.novelty) : t.novelty,
+      Number.isFinite(Number(t.momentum)) ? formatDecimal(t.momentum) : t.momentum,
+      t.impactScore,
+      ...(t.metrics || t.keys || []),
+      ...((t.kpis || []).flatMap((k)=> [k.value, k.label]))
+    ]
+      .filter(Boolean)
+      .map(normalizeText)
+      .join(' ');
+    return parts;
+  };
+  let result = items.filter((t)=>{
+    const bag = makeBag(t);
+    return normalizedTerms.every((term)=> bag.includes(term));
+  });
+  if(!result.length){
+    result = items.filter((t)=>{
+      const bag = makeBag(t);
+      return normalizedTerms.some((term)=> bag.includes(term));
+    });
+  }
+  return result;
+}
+
+function updateToggleButtons(){
+  viewToggleButtons.forEach((btn)=>{
+    const btnView = btn.getAttribute('data-view');
+    const isActive = btnView === activeView;
+    btn.classList.toggle('is-active', isActive);
+    btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    btn.setAttribute('tabindex', isActive ? '0' : '-1');
+  });
+}
+
+function updateEmptyStates(){
+  const radarItems = filteredByView.radar || [];
+  const wsItems = filteredByView.whitespace || [];
+  if(radarEmptyEl){
+    radarEmptyEl.hidden = activeView !== 'radar' || radarItems.length > 0;
+  }
+  if(whiteSpaceEmptyEl){
+    whiteSpaceEmptyEl.hidden = activeView !== 'whitespace' || wsItems.length > 0;
+  }
+}
+
+function applyFilteredView(){
+  updateToggleButtons();
+  const items = filteredByView[activeView] || [];
+  if(radarEl){
+    radarEl.hidden = activeView !== 'radar';
+    radarEl.setAttribute('aria-hidden', activeView !== 'radar' ? 'true' : 'false');
+  }
+  if(whiteSpaceEl){
+    whiteSpaceEl.hidden = activeView !== 'whitespace';
+    whiteSpaceEl.setAttribute('aria-hidden', activeView !== 'whitespace' ? 'true' : 'false');
+  }
+  if(whiteSpaceAboutEl){
+    whiteSpaceAboutEl.hidden = activeView !== 'whitespace';
+  }
+  if(dashboardLinkEl){
+    dashboardLinkEl.hidden = activeView !== 'radar';
+  }
+  if(activeView === 'radar'){
+    renderRadar(items);
+  } else {
+    renderWhiteSpace(items);
+  }
+  renderBoard(items, activeView);
+  updateEmptyStates();
+}
+
+function setActiveView(view){
+  if(view !== 'radar' && view !== 'whitespace'){ return; }
+  if(activeView === view){
+    updateToggleButtons();
+    return;
+  }
+  activeView = view;
+  if(lastSearchTerms.length){
+    filteredByView[view] = filterList(baseByView[view], lastSearchTerms);
+  }
+  applyFilteredView();
 }
 
 // === ДОСКА ===
 function chip(el, text){ const s=document.createElement('span'); s.className='chip'; s.textContent=text; el.appendChild(s); }
 
-function renderBoard(list){
+function renderBoard(list, view = activeView){
   if(!boardEl) return;
   const items = Array.isArray(list) ? list : [];
   boardEl.innerHTML = '';
+  boardEl.dataset.view = view;
   const hasItems = items.length > 0;
   if(boardEmptyEl){
     boardEmptyEl.hidden = hasItems;
@@ -684,7 +1360,15 @@ function renderBoard(list){
   }
   items.forEach((item, idx)=>{
     const a = document.createElement('a');
-    a.href = item.link; a.className='tile'; a.setAttribute('data-id', item.id);
+    const link = (item.link || '').toString().trim();
+    const disabled = !link || link === '#';
+    a.href = disabled ? '#' : link;
+    a.className = 'tile';
+    a.setAttribute('data-id', item.id);
+    if(disabled){
+      a.setAttribute('data-disabled','true');
+      a.addEventListener('click', (event)=> event.preventDefault());
+    }
 
     const title = document.createElement('div'); title.className='title';
     const head = document.createElement('div');
@@ -724,6 +1408,13 @@ function renderBoard(list){
       a.appendChild(chips);
     }
 
+    if(item.story){
+      const story = document.createElement('p');
+      story.className = 'tile-story';
+      story.textContent = item.story;
+      a.appendChild(story);
+    }
+
     const kpiItems = (item.kpis || []).slice(0,3);
     if(kpiItems.length){
       const kpiList = document.createElement('ul');
@@ -752,66 +1443,65 @@ function setupSearch(){
   const input = document.getElementById('q');
   const clearBtn = document.getElementById('clearBtn');
   if(!input) return;
-  const base = [...technologies];
-  const norm = (s)=> (s||'').toString().toLowerCase();
   const updateClearState = ()=>{
     if(clearBtn){
       clearBtn.disabled = !input.value.trim();
     }
   };
-  function filter(){
-    const terms = norm(input.value).split(/\s+/).filter(Boolean);
-    if(!terms.length){
-      renderBoard(base);
-      renderRadar(base);
-      updateClearState();
-      return;
-    }
-    const makeBag = (t)=> [
-      t.name,
-      t.slug,
-      t.ring,
-      t.summary,
-      ringLabelsById[t.ring],
-      ...(t.metrics || t.keys || []),
-      ...((t.kpis || []).flatMap((k)=> [k.value, k.label]))
-    ]
-      .filter(Boolean)
-      .map(norm)
-      .join(' ');
-    let res = base.filter(t=> {
-      const bag = makeBag(t);
-      return terms.every(term => bag.includes(term));
-    });
-    if(!res.length){
-      res = base.filter(t=> {
-        const bag = makeBag(t);
-        return terms.some(term => bag.includes(term));
-      });
-    }
-    renderBoard(res);
-    renderRadar(res);
+  const runFilter = ()=>{
+    const terms = normalizeText(input.value).split(/\s+/).filter(Boolean);
+    lastSearchTerms = terms;
+    filteredByView.radar = filterList(baseByView.radar, terms);
+    filteredByView.whitespace = filterList(baseByView.whitespace, terms);
+    applyFilteredView();
     updateClearState();
-  }
-  input.addEventListener('input', filter);
+  };
+  input.addEventListener('input', runFilter);
   if(clearBtn){
     clearBtn.addEventListener('click', ()=>{
       input.value = '';
-      filter();
+      lastSearchTerms = [];
+      filteredByView.radar = baseByView.radar;
+      filteredByView.whitespace = baseByView.whitespace;
+      applyFilteredView();
       input.focus();
+      updateClearState();
     });
   }
   updateClearState();
 }
 
 // init
-  renderRadar(technologies);
-  renderBoard(technologies);
   setupSearch();
-  let radarResizeTimer;
+  viewToggleButtons.forEach((btn, index)=>{
+    const view = btn.getAttribute('data-view');
+    if(!view){ return; }
+    btn.addEventListener('click', ()=> setActiveView(view));
+    btn.addEventListener('keydown', (event)=>{
+      if(event.key === 'ArrowRight' || event.key === 'ArrowLeft'){
+        event.preventDefault();
+        const direction = event.key === 'ArrowRight' ? 1 : -1;
+        const nextIndex = (index + direction + viewToggleButtons.length) % viewToggleButtons.length;
+        const nextBtn = viewToggleButtons[nextIndex];
+        nextBtn?.focus();
+        const nextView = nextBtn?.getAttribute('data-view');
+        if(nextView){ setActiveView(nextView); }
+      }
+    });
+  });
+  filteredByView.radar = baseByView.radar;
+  filteredByView.whitespace = baseByView.whitespace;
+  applyFilteredView();
+  let resizeTimer;
   window.addEventListener('resize', ()=>{
-    clearTimeout(radarResizeTimer);
-    radarResizeTimer = setTimeout(()=> renderRadar(lastRadarData), 160);
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(()=>{
+      if(activeView === 'radar'){
+        renderRadar(lastRadarData);
+      } else {
+        renderWhiteSpace(lastWhiteSpaceData);
+      }
+    }, 160);
   });
 
 const loginLink = document.querySelector('.login-link');


### PR DESCRIPTION
## Summary
- add a radar/white space toggle with descriptive copy on the main page
- render the curated white space dataset with a bespoke bubble chart and shared tooltips
- update the technology board and search logic to handle both visualization modes

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68fe4d2c809883338d58ebbaeef409a8