### PR TITLE
Ensure paragraph spacing is preserved after page breaks

### DIFF
--- a/scripts/build_digest_pdf.py
+++ b/scripts/build_digest_pdf.py
@@ -479,6 +479,8 @@ class LayoutEngine:
         for idx, (indent, line) in enumerate(lines):
             if self.cursor_y < MARGIN_BOTTOM + paragraph.size:
                 self._new_page()
+                if idx == 0:
+                    self.cursor_y -= paragraph.space_before
             x = MARGIN_LEFT + indent
             y = self.cursor_y
             color = paragraph.color


### PR DESCRIPTION
## Summary
- reapply paragraph spacing when a page break occurs before the first line so headings and paragraphs keep consistent top margins

## Testing
- python3 scripts/build_digest_pdf.py

------
https://chatgpt.com/codex/tasks/task_e_68fe746fcf9c833396985022fd03f562