### PR TITLE
Add embedded dashboard page with navigation

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Интерактивный дашборд</title>
+  <meta name="description" content="Интерактивный дашборд встраивается на страницу через iframe." />
+  <script>
+    (function(){
+      var doc = document.documentElement;
+      doc.classList.add('auth-check');
+      try{
+        if(localStorage.getItem('sci-auth') === 'true'){
+          doc.classList.add('auth-ok');
+        } else {
+          window.location.replace('/login/');
+        }
+      } catch(err){
+        window.location.replace('/login/');
+      }
+    })();
+  </script>
+  <link rel="icon" type="image/svg+xml" href="./assets/logo-transparent.svg" />
+  <style>
+    html.auth-check body{ visibility:hidden; }
+    html.auth-check.auth-ok body{ visibility:visible; }
+    :where([hidden]){ display:none !important; }
+    :root{
+      --bg:#f8fafc;
+      --card:#ffffff;
+      --card-alt:#f1f5f9;
+      --text:#0f172a;
+      --muted:#64748b;
+      --accent:#2563eb;
+      --accent-strong:#1d4ed8;
+      --accent-light:#60a5fa;
+      --accent-soft:#dbeafe;
+      --border:#e2e8f0;
+      --shadow:0 20px 48px rgba(15,23,42,.08);
+      --radius:18px;
+    }
+    *, *::before, *::after{ box-sizing:border-box; }
+    html,body{ margin:0; padding:0; min-height:100%; background:var(--bg); color:var(--text); font:16px/1.55 "Inter", "SF Pro Text", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; }
+    body{ display:flex; flex-direction:column; }
+    .page-header{ background:var(--card); border-bottom:1px solid rgba(148,163,184,.28); box-shadow:var(--shadow); }
+    .page-header__inner{ max-width:1100px; margin:0 auto; padding:20px; display:flex; align-items:center; gap:18px; flex-wrap:wrap; }
+    .logo-link{ display:inline-flex; align-items:center; justify-content:center; border-radius:12px; text-decoration:none; }
+    .logo-link:focus-visible{ outline:3px solid rgba(37,99,235,.35); outline-offset:4px; }
+    .logo{ height:46px; width:auto; }
+    .page-title{ margin:0; font-size:clamp(22px,2.6vw,28px); font-weight:700; letter-spacing:.2px; color:var(--text); }
+    .page-actions{ margin-left:auto; display:flex; align-items:center; gap:12px; flex-wrap:wrap; }
+    .back-link{ display:inline-flex; align-items:center; gap:10px; padding:10px 18px; border-radius:12px; border:1px solid var(--border); background:var(--card-alt); color:var(--accent-strong); font-weight:600; text-decoration:none; transition:background .2s ease, color .2s ease, transform .2s ease; }
+    .back-link:hover{ background:var(--accent-soft); color:var(--accent); transform:translateY(-1px); }
+    .back-link:focus-visible{ outline:3px solid rgba(37,99,235,.3); outline-offset:3px; }
+    .back-link svg{ width:18px; height:18px; stroke:currentColor; }
+    main{ flex:1; display:flex; }
+    .iframe-shell{ flex:1; display:flex; align-items:stretch; justify-content:center; padding:32px 20px 44px; }
+    .iframe-card{ width:100%; max-width:1100px; background:var(--card); border-radius:calc(var(--radius) + 6px); border:1px solid var(--border); box-shadow:var(--shadow); padding:20px; display:grid; gap:20px; }
+    .iframe-card__heading{ display:flex; flex-direction:column; gap:6px; }
+    .iframe-card__title{ margin:0; font-size:clamp(20px,2.4vw,24px); font-weight:700; }
+    .iframe-card__subtitle{ margin:0; color:var(--muted); font-size:15px; }
+    .iframe-wrap{ position:relative; border-radius:14px; overflow:hidden; border:1px solid rgba(148,163,184,.35); box-shadow:0 18px 36px rgba(37,99,235,.12); background:linear-gradient(135deg, rgba(219,234,254,.65), rgba(191,219,254,.3)); }
+    .iframe-wrap::before{ content:""; position:absolute; inset:0; pointer-events:none; background:linear-gradient(135deg, rgba(148,163,184,.15), transparent 55%); mix-blend-mode:soft-light; }
+    iframe{ position:relative; width:100%; height:70vh; min-height:520px; border:0; background:#fff; border-radius:inherit; }
+    .iframe-footer{ display:flex; align-items:center; justify-content:space-between; gap:16px; flex-wrap:wrap; color:var(--muted); font-size:14px; }
+    .iframe-footer a{ color:var(--accent); text-decoration:none; font-weight:600; }
+    .iframe-footer a:hover{ color:var(--accent-strong); text-decoration:underline; }
+  </style>
+</head>
+<body>
+  <header class="page-header">
+    <div class="page-header__inner">
+      <a class="logo-link" href="./" aria-label="На главную">
+        <img class="logo" src="./assets/logo.svg" alt="Tech Digest" />
+      </a>
+      <h1 class="page-title">Интерактивный дашборд</h1>
+      <div class="page-actions">
+        <a class="back-link" href="./">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.8">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 6.75L4.5 12l6 5.25M19.5 12H4.5" />
+          </svg>
+          На главную
+        </a>
+      </div>
+    </div>
+  </header>
+  <main>
+    <div class="iframe-shell">
+      <div class="iframe-card">
+        <div class="iframe-card__heading">
+          <h2 class="iframe-card__title">Цифровой радар технологий</h2>
+          <p class="iframe-card__subtitle">Обновляется автоматически каждые 60 секунд — удобно отслеживать изменения в режиме реального времени.</p>
+        </div>
+        <div class="iframe-wrap">
+          <iframe src="https://datalens.yandex/unblwg4lldxmf?embedded=1&_theme=white&_autoupdate=60" title="Дашборд DataLens" allowfullscreen loading="lazy"></iframe>
+        </div>
+        <div class="iframe-footer">
+          <span>Если дашборд не загружается, убедитесь, что доступны сервисы Яндекс DataLens.</span>
+          <a href="https://datalens.yandex/unblwg4lldxmf" target="_blank" rel="noopener">Открыть в новом окне</a>
+        </div>
+      </div>
+    </div>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -321,7 +321,7 @@
           <button type="button" class="view-toggle__btn is-active" data-view="radar" role="tab" aria-selected="true" aria-controls="radar" id="viewRadar">Радар</button>
           <button type="button" class="view-toggle__btn" data-view="whitespace" role="tab" aria-selected="false" aria-controls="whiteSpace" id="viewWhiteSpace">White Space</button>
         </div>
-        <a class="radar-dashboard-link" href="https://datalens.yandex/unblwg4lldxmf" target="_blank" rel="noopener">Перейти в дашборд</a>
+        <a class="radar-dashboard-link" href="./dashboard.html">Перейти на дашборд</a>
       </div>
       <div id="radar" class="radar" role="tabpanel" aria-labelledby="viewRadar"></div>
       <div id="whiteSpace" class="whitespace" role="tabpanel" aria-labelledby="viewWhiteSpace" hidden></div>


### PR DESCRIPTION
## Summary
- add a dedicated dashboard page that embeds the DataLens iframe with site styling and back navigation
- update the main page dashboard button to link to the new internal page

## Testing
- not run (static content changes only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917073d76988333a83c97c21cb4c49d)